### PR TITLE
Mdx

### DIFF
--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -75,7 +75,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # - windows-latest
         ocaml-compiler:
           - 4.14.x
           - 5.1.x

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -74,10 +74,14 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # - macos-latest
-          # - windows-latest
+          - macos-latest
+          - windows-latest
         ocaml-compiler:
+          - 4.14.x
           - 5.1.x
+        exclude:
+          - os: "ubuntu-latest"
+            ocaml-compiler: 4.14.x
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Main changes
 
-- Added hash-consed nodes and functors to build hash-consed maps and sets
+- Added hash-consed nodes and functors to build hash-consed maps and sets.
+- Added new functions `fold_on_nonequal_inter` and `fold_on_nonequal_union` to maps.
 - Now support using negative keys, removed `zarith` dependency.
 - Fixed some bugs
 
@@ -26,11 +27,14 @@
   `pop_unsigned_minimum`, `pop_unsigned_maximum`, `unsigned_min_elt`
   and `unsigned_max_elt` respectively, to clarify that these functions consider
   negative numbers as larger than positive ones.
+- Added new functions `fold_on_nonequal_inter` and `fold_on_nonequal_union` to maps.
 - Fixed a bug where `NodeWithId` wasn't incrementing ids properly
 - `zarith` is no longer a dependency, used GCC's `__builtin_clz` as a faster
   method of finding an integer's highest bit.
 - Fixed a bug where `pop_minimum` and `pop_maximum` could throw a private exception
   `Dissappeared` when using `WeakNode`.
+- Fixed a possible assertion error when using `idempotent_subset_domain_forall2`
+  with `WeakNode`.
 
 # v0.9.0 - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ module MakeHeterogeneousMap(Key: HETEROGENEOUS_KEY)(Value: HETEROGENEOUS_VALUE) 
 There are also [hash-consed](https://en.wikipedia.org/wiki/Hash_consing) versions
 of these four functors: `MakeHashconsedMap`, `MakeHashconsedSet`,
 `MakeHashconsedHeterogeneousMap` and `MakeHashconsedHeterogeneousSet`.
-These uniquely number their nodes, and ensure nodes with the same contents are
-always physically equal. With this unique numbering:
+These uniquely number their nodes, which means:
 - `equal` and `compare` become constant time operations;
 - two maps with the same bindings (where keys are compared by `KEY.to_int` and
   values by `HASHED_VALUE.polyeq`) will always be physically equal;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patricia Tree
 
-[![Latest version](https://img.shields.io/badge/version-0.9.0-yellow)](https://github.com/codex-semantics-library/patricia-tree/releases)
+[![Latest version](https://img.shields.io/badge/version-0.10.0-yellow)](https://github.com/codex-semantics-library/patricia-tree/releases)
 [![OCaml Version](https://img.shields.io/badge/OCaml-4.14_--_5.x-blue?logo=ocaml&logoColor=white)](https://github.com/codex-semantics-library/patricia-tree/blob/main/dune-project)
 [![GitHub License](https://img.shields.io/github/license/codex-semantics-library/patricia-tree)](https://github.com/codex-semantics-library/patricia-tree/blob/main/LICENSE)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/codex-semantics-library/patricia-tree/ocaml.yml)](https://github.com/codex-semantics-library/patricia-tree/actions/workflows/ocaml.yml)

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Alternatively, you can clone the source repository and install with [dune](https
 git clone git@github.com:codex-semantics-library/patricia-tree.git
 cd patricia-tree
 opan install . --deps-only
-dune build
+dune build -p patricia-tree
 dune install
 # To build documentation
-opam install odoc
+opam install . --deps-only --with-doc
 dune build @doc
 ```
 

--- a/dune
+++ b/dune
@@ -30,6 +30,10 @@
 (documentation
  (package patricia-tree))
 
+(mdx
+ (files *.mld)
+ (libraries patricia-tree))
+
 ;; For test purposes only.
 
 (library

--- a/dune
+++ b/dune
@@ -31,7 +31,7 @@
  (package patricia-tree))
 
 (mdx
- (files *.mld)
+ (files *.mld *.mli)
  (libraries patricia-tree))
 
 ;; For test purposes only.

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;  This file is part of the Codex semantics library                      ;;
@@ -25,7 +25,7 @@
 
 (version 0.10.0)
 
-(using mdx 0.4)
+(using mdx 0.2)
 
 (maintainers "Dorian Lesbre <dorian.lesbre@cea.fr>")
 
@@ -62,6 +62,10 @@
   (ppx_inline_test
    (and
     (>= "v0.16.0")
+    :with-test))
+  (mdx
+   (and
+    (>="2.4.1")
     :with-test))
   (odoc
    (and

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.8)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;  This file is part of the Codex semantics library                      ;;
@@ -24,6 +24,8 @@
 (name patricia-tree)
 
 (version 0.10.0)
+
+(using mdx 0.4)
 
 (maintainers "Dorian Lesbre <dorian.lesbre@cea.fr>")
 

--- a/dune-project
+++ b/dune-project
@@ -38,9 +38,9 @@
 (bug_reports
  "https://github.com/codex-semantics-library/patricia-tree/issues")
 
-(homepage "https://codex.top/patricia-tree/")
+(homepage "https://codex.top/api/patricia-tree/")
 
-(documentation "https://codex.top/patricia-tree/")
+(documentation "https://codex.top/api/patricia-tree/")
 
 (source
  (github "codex-semantics-library/patricia-tree"))
@@ -65,7 +65,7 @@
     :with-test))
   (mdx
    (and
-    (>="2.4.1")
+    (>= "2.4.1")
     :with-test))
   (odoc
    (and

--- a/index.mld
+++ b/index.mld
@@ -115,8 +115,7 @@ The functors used to build maps and sets are the following:
   There are also {{: https://en.wikipedia.org/wiki/Hash_consing}hash-consed} versions
   of these four functors: {{!PatriciaTree.MakeHashconsedMap}[MakeHashconsedMap]}, {{!PatriciaTree.MakeHashconsedSet}[MakeHashconsedSet]},
   {{!PatriciaTree.MakeHashconsedHeterogeneousMap}[MakeHashconsedHeterogeneousMap]} and {{!PatriciaTree.MakeHashconsedHeterogeneousSet}[MakeHashconsedHeterogeneousSet]}.
-  These uniquely number their nodes, and ensures {b nodes with the same contents are
-  always physically equal}. With this unique numbering:
+  These uniquely number their nodes, which means:
   - [equal] and [compare] become constant time operations;
   - two maps with the same bindings (where keys are compared by {{!PatriciaTree.KEY.to_int}[KEY.to_int]} and
     values by {{!PatriciaTree.HASHED_VALUE.polyeq}[HASHED_VALUE.polyeq]}) will always be physically equal;

--- a/index.mld
+++ b/index.mld
@@ -373,7 +373,7 @@ away as we would like a bit more time using this library before doing so.
 There is a bug in the OCaml typechecker which prevents us from directly
 defining non-generic maps as instances of generic maps. To avoid this, non-generic maps
 use a separate value type (instead of just using ['b])
-{@python[
+{[
 type (_, 'b) snd = Snd of 'b [@@unboxed]
 ]}
 It should not incur any extra performance cost as it is unboxed, but can appear

--- a/index.mld
+++ b/index.mld
@@ -21,12 +21,12 @@ as part of the {{: Codex semantics library}https://codex.top/}, developed at
 {1 Installation}
 
 This library can be installed with {{: https://opam.ocaml.org/}opam}:
-{@bash[
+{@shell[
 opam install patricia-tree
 ]}
 
 Alternatively, you can clone the source repository and install with {{: https://dune.build/}dune}:
-{@bash[
+{@shell[
 git clone git@github.com:codex-semantics-library/patricia-tree.git
 opam install . --deps-only
 cd patricia-tree
@@ -97,13 +97,13 @@ The functors used to build maps and sets are the following:
 {ul
 {li For homogeneous (non-generic) maps and sets: {{!PatriciaTree.MakeMap}[MakeMap]} and
     {{!PatriciaTree.MakeSet}[MakeSet]}. These are similar to the standard library's maps and sets.
-    {[
+    {@ocaml skip[
       module MakeMap(Key: KEY) : MAP with type key = Key.t
       module MakeSet(Key: KEY) : SET with type elt = Key.t
     ]}}
 {li For Heterogeneous (generic) maps and sets: {{!PatriciaTree.MakeHeterogeneousMap}[MakeHeterogeneousMap]}
     and {{!PatriciaTree.MakeHeterogeneousSet}[MakeHeterogeneousSet]}.
-    {[
+    {@ocaml skip[
       module MakeHeterogeneousMap(Key: HETEROGENEOUS_KEY)(Value: HETEROGENEOUS_VALUE) :
         HETEROGENEOUS_MAP
         with type 'a key = 'a Key.t
@@ -185,109 +185,180 @@ Here is a brief overview of the various module types of our library:
 
 Here is a small example of a non-generic map:
 
-{[
-(** Create a key struct *)
-module Int (*: PatriciaTree.KEY*) = struct
-  type t = int
-  let to_int x = x
-end
-
-(** Call the map and/or set functors *)
-module IMap = PatriciaTree.MakeMap(Int)
-module ISet = PatriciaTree.MakeSet(Int)
-
-(** Use all the usual map operations *)
-let map =
-  IMap.empty |>
-  IMap.add 1 "hello" |>
-  IMap.add 2 "world" |>
-  IMap.add 3 "how do you do?"
-  (* Also has an [of_list] and [of_seq] operation for initialization *)
-
-let _ = IMap.find 1 map (* "hello" *)
-let _ = IMap.cardinal map (* 3 *)
-
-(** The strength of Patricia Tree is the speedup of operation on multiple maps
-    with common subtrees. *)
-let map2 =
-  IMap.idempotent_inter_filter (fun _key _l _r -> None)
-  (IMap.add 4 "something" map) (IMap.add 5 "something else" map)
-let _ = map == map2 (* true *)
-(* physical equality is preserved as much as possible, although some intersections
-   may need to build new nodes and won't be fully physically equal, they will
-   still share subtrees if possible. *)
-
-(** Many operations preserve physical equality whenever possible *)
-let _ = (IMap.add 1 "hello" map) == map (* true: already present *)
-
-(** Example of cross map/set operation: only keep the bindings of [map]
-    whose keys are in a given set *)
-let set = ISet.of_list [1; 3]
-module CrossOperations = IMap.WithForeign(ISet.BaseMap)
-let restricted_map = CrossOperations.nonidempotent_inter
-  { f = fun _key value () -> value } map set
-]}
+{ol
+{li Start by creating a key module:
+  {@ocaml[
+  module IntKey : PatriciaTree.KEY with type t = int = struct
+    type t = int
+    let to_int x = x
+  end
+  ]}}
+{li Use it to instanciate the map/set functors:
+  {[
+  module IMap : PatriciaTree.MAP with type key = int = PatriciaTree.MakeMap(IntKey);;
+  module ISet : PatriciaTree.SET with type elt = int = PatriciaTree.MakeSet(IntKey);;
+  ]}}
+{li You can now use it as you would any other map:
+  {[
+  # let map =
+    IMap.empty |>
+    IMap.add 1 "hello" |>
+    IMap.add 2 "world" |>
+    IMap.add 3 "how do you do?";;
+  val map : string IMap.t = <abstr>
+  ]}
+  (We also have {{!PatriciaTree.MAP.of_list}[of_list]} and
+  {{!PatriciaTree.MAP.of_seq}[of_seq]} functions for quick initialization)
+  {[
+  # IMap.find 1 map;;
+  - : string = "hello"
+  # IMap.cardinal map;;
+  - : int = 3
+  ]}}
+{li The strength of Patricia Tree is the speedup of operation on multiple maps
+    with common subtrees.
+  {[
+  # let map2 =
+      IMap.idempotent_inter_filter (fun _key _l _r -> None)
+        (IMap.add 4 "something" map)
+        (IMap.add 5 "something else" map);;
+  val map2 : string IMap.t = <abstr>
+  # map == map2;;
+  - : bool = true
+  ]}
+  Physical equality is preserved as much as possible, although some intersections
+  may need to build new nodes and won't be fully physically equal, they will
+  still share subtrees if possible.
+  {[
+  # let str = IMap.find 1 map;;
+  val str : string = "hello"
+  # IMap.add 1 str map == map (* already present *);;
+  - : bool = true
+  # IMap.add 1 "hello" map == map
+    (* new string copy isn't physically equal to the old one *);;
+  - : bool = false
+  ]}
+  Note that physical equality ins't preserved when creating new copies of values
+  (the newly created string ["hello"] isn't physically equal to [str]).
+  It can also fail when maps have the same bindings but were created differently:
+  {[
+    # let map3 = IMap.remove 2 map;;
+    val map3 : string IMap.t = <abstr>
+    # IMap.add 2 (IMap.find 2 map) map3 == map;;
+    - : bool = false
+  ]}
+  This is because they were created through different processes. They will still
+  share subtrees. If you want to maintain full physical equality (and thus get
+  cheap equality test between maps), use the provided
+  {{!PatriciaTree.section-hash_consed}hash-consed maps and sets}.}
+{li Our library also allows cross map/set operations.
+  For example, you can only keep the bindings of [map]
+  whose keys are in a given set:
+  {[
+    let set = ISet.of_list [1; 3]
+    module CrossOperations = IMap.WithForeign(ISet.BaseMap)
+    let restricted_map = CrossOperations.nonidempotent_inter
+      { f = fun _key value () -> value } map set
+  ]}
+  {[
+    # IMap.to_list map;;
+    - : (int * string) list = [(1, "hello"); (2, "world"); (3, "how do you do?")]
+    # IMap.to_list restricted_map;;
+    - : (int * string) list = [(1, "hello"); (3, "how do you do?")]
+  ]}
+}}
 
 {2 Heterogeneous map}
 
-{[
-(** Very small typed expression language *)
-type 'a expr =
-  | G_Const_Int : int -> int expr
-  | G_Const_Bool : bool -> bool expr
-  | G_Addition : int expr * int expr -> int expr
-  | G_Equal : 'a expr * 'a expr -> bool expr
+Heterogeneous maps work very similarly to homogeneous ones, but come with extra
+liberty of having a generic type as a key.
 
-module Expr : PatriciaTree.HETEROGENEOUS_KEY with type 'a t = 'a expr = struct
-  type 'a t = 'a expr
+{ol
+{li Here is a GADT example to use for our keys: a small typed expression language.
+    {[
+      type 'a expr =
+        | G_Const_Int : int -> int expr
+        | G_Const_Bool : bool -> bool expr
+        | G_Addition : int expr * int expr -> int expr
+        | G_Equal : 'a expr * 'a expr -> bool expr
+    ]}
+    We can create our {{!PatriciaTree.HETEROGENEOUS_KEY}[HETEROGENEOUS_KEY]} functor
+    parameter using this type has follows:
+    {[
+      module Expr : PatriciaTree.HETEROGENEOUS_KEY with type 'a t = 'a expr = struct
+        type 'a t = 'a expr
 
-  (** Injective, so long as expression are small enough
-      (encodes the constructor discriminant in two lowest bits).
-      Ideally, use a hash-consed type, to_int needs to be fast *)
-  let rec to_int : type a. a expr -> int = function
-    | G_Const_Int i ->   0 + 4*i
-    | G_Const_Bool b ->  1 + 4*(if b then 1 else 0)
-    | G_Addition(l,r) -> 2 + 4*(to_int l mod 10000 + 10000*(to_int r))
-    | G_Equal(l,r) ->    3 + 4*(to_int l mod 10000 + 10000*(to_int r))
+        (** Injective, so long as expression are small enough
+            (encodes the constructor discriminant in two lowest bits).
+            Ideally, use a hash-consed type, to_int needs to be fast *)
+        let rec to_int : type a. a expr -> int = function
+          | G_Const_Int i ->   0 + 4*i
+          | G_Const_Bool b ->  1 + 4*(if b then 1 else 0)
+          | G_Addition(l,r) -> 2 + 4*(to_int l mod 10000 + 10000*(to_int r))
+          | G_Equal(l,r) ->    3 + 4*(to_int l mod 10000 + 10000*(to_int r))
 
-  (** Full polymorphic equality *)
-  let rec polyeq : type a b. a expr -> b expr -> (a, b) PatriciaTree.cmp =
-    fun l r -> match l, r with
-    | G_Const_Int l, G_Const_Int r -> if l = r then Eq else Diff
-    | G_Const_Bool l, G_Const_Bool r -> if l = r then Eq else Diff
-    | G_Addition(ll, lr), G_Addition(rl, rr) -> (
-        match polyeq ll rl with
-        | Eq -> polyeq lr rr
-        | Diff -> Diff)
-    | G_Equal(ll, lr), G_Equal(rl, rr) ->    (
-        match polyeq ll rl with
-        | Eq -> (match polyeq lr rr with Eq -> Eq | Diff -> Diff) (* Match required by typechecker *)
-        | Diff -> Diff)
-    | _ -> Diff
-end
+        (** Full polymorphic equality *)
+        let rec polyeq : type a b. a expr -> b expr -> (a, b) PatriciaTree.cmp =
+          fun l r -> match l, r with
+          | G_Const_Int l, G_Const_Int r -> if l = r then Eq else Diff
+          | G_Const_Bool l, G_Const_Bool r -> if l = r then Eq else Diff
+          | G_Addition(ll, lr), G_Addition(rl, rr) -> (
+              match polyeq ll rl with
+              | Eq -> polyeq lr rr
+              | Diff -> Diff)
+          | G_Equal(ll, lr), G_Equal(rl, rr) ->    (
+              match polyeq ll rl with
+              | Eq -> (match polyeq lr rr with Eq -> Eq | Diff -> Diff) (* Match required by typechecker *)
+              | Diff -> Diff)
+          | _ -> Diff
+      end
+    ]}}
+{li We can now instanciate our map functor. Note that in the heterogeneous case,
+    we must also specify the value type (second functor argument) and how it depends
+    on the key type (first parameter) and the map type (second parameter).
+    Here the value only depends on the type of the key, not that of the map
+    {[
+      module EMap = PatriciaTree.MakeHeterogeneousMap(Expr)(struct type ('a, _) t = 'a end)
+    ]}}
+{li You can now use this as you would any other dependent map:
+    {[
+      # let map : unit EMap.t =
+        EMap.empty |>
+        EMap.add (G_Const_Bool false) false |>
+        EMap.add (G_Const_Int 5) 5 |>
+        EMap.add (G_Addition (G_Const_Int 3, G_Const_Int 6)) 9 |>
+        EMap.add (G_Equal (G_Const_Bool false, G_Equal (G_Const_Int 5, G_Const_Int 7))) true
+      val map : unit EMap.t = <abstr>
+      # EMap.find (G_Const_Bool false) map;;
+      - : bool = false
+      # EMap.find (G_Const_Int 5) map;;
+      - : int = 5
+      # EMap.cardinal map;;
+      - : int = 4
+    ]}}
+{li Physical equality preservation allows fast operations on multiple maps with common
+    ancestors. In the heterogeneous case, these functions are a bit more complex
+    since OCaml requires that first-order polymorphic functions be wrapped in records:
+    {[
+      # let map2 = EMap.idempotent_inter_filter
+          { f = fun _key _l _r -> None } (* polymorphic 1rst order functions are wrapped in records *)
+          (EMap.add (G_Const_Int 0) 8 map)
+          (EMap.add (G_Const_Int 0) 9 map)
+      val map2 : unit EMap.t = <abstr>
+    ]}
+    Even though [map] and [map2] have the same elements, they may not always
+    be physically equal:
+    {[
+      # map == map2;;
+      - : bool = false
+    ]}
+    This is because they were created through different processes. They will still
+    share subtrees. If you want to maintain full physical equality (and thus get
+    cheap equality test between maps), use the provided
+    {{!PatriciaTree.section-hash_consed}hash-consed maps and sets}.
+}
+}
 
-(** Map from expression to their values: here the value only depends on the type
-    of the key, not that of the map *)
-module EMap = PatriciaTree.MakeHeterogeneousMap(Expr)(struct type ('a, _) t = 'a end)
-
-(** You can use all the usual map operations *)
-let map : unit EMap.t =
-  EMap.empty |>
-  EMap.add (G_Const_Bool false) false |>
-  EMap.add (G_Const_Int 5) 5 |>
-  EMap.add (G_Addition (G_Const_Int 3, G_Const_Int 6)) 9 |>
-  EMap.add (G_Equal (G_Const_Bool false, G_Equal (G_Const_Int 5, G_Const_Int 7))) true
-
-let _ = EMap.find (G_Const_Bool false) map (* false *)
-let _ = EMap.cardinal map (* 4 *)
-
-(** Fast operations on multiple maps with common subtrees. *)
-let map2 =
-  EMap.idempotent_inter_filter
-    { f = fun _key _l _r -> None } (* polymorphic 1rst order functions are wrapped in records *)
-    (EMap.add (G_Const_Int 0) 8 map)
-    (EMap.add (G_Const_Int 0) 9 map)
-]}
 
 {1 Release status}
 
@@ -303,7 +374,7 @@ away as we would like a bit more time using this library before doing so.
 There is a bug in the OCaml typechecker which prevents us from directly
 defining non-generic maps as instances of generic maps. To avoid this, non-generic maps
 use a separate value type (instead of just using ['b])
-{[
+{@python[
 type (_, 'b) snd = Snd of 'b [@@unboxed]
 ]}
 It should not incur any extra performance cost as it is unboxed, but can appear

--- a/index.mld
+++ b/index.mld
@@ -28,9 +28,9 @@ opam install patricia-tree
 Alternatively, you can clone the source repository and install with {{: https://dune.build/}dune}:
 {@bash skip[
 git clone git@github.com:codex-semantics-library/patricia-tree.git
-opam install . --deps-only
 cd patricia-tree
-dune build
+opan install . --deps-only
+dune build -p patricia-tree
 dune install
 # To build documentation
 opam install . --deps-only --with-doc

--- a/index.mld
+++ b/index.mld
@@ -15,7 +15,7 @@ under an {{: https://choosealicense.com/licenses/lgpl-2.1/}LGPL-2.1} license.
 
 This library was written by {{: https://www.researchgate.net/profile/Matthieu-Lemerre}Matthieu Lemerre},
 then further improved by {{: https://www.normalesup.org/~dlesbre/}Dorian Lesbre},
-as part of the {{: Codex semantics library}https://codex.top/}, developed at
+as part of the {{: https://codex.top/}Codex semantics library}, developed at
 {{: https://list.cea.fr/en/} CEA List}.
 
 {1 Installation}

--- a/index.mld
+++ b/index.mld
@@ -21,12 +21,12 @@ as part of the {{: https://codex.top/}Codex semantics library}, developed at
 {1 Installation}
 
 This library can be installed with {{: https://opam.ocaml.org/}opam}:
-{@shell[
+{@bash skip[
 opam install patricia-tree
 ]}
 
 Alternatively, you can clone the source repository and install with {{: https://dune.build/}dune}:
-{@shell[
+{@bash skip[
 git clone git@github.com:codex-semantics-library/patricia-tree.git
 opam install . --deps-only
 cd patricia-tree

--- a/index.mld
+++ b/index.mld
@@ -33,7 +33,7 @@ cd patricia-tree
 dune build
 dune install
 # To build documentation
-opam install odoc
+opam install . --deps-only --with-doc
 dune build @doc
 ]}
 

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -9,8 +9,8 @@ authors: [
   "Dorian Lesbre <dorian.lesbre@cea.fr>"
 ]
 license: "LGPL-2.1-only"
-homepage: "https://codex.top/patricia-tree/"
-doc: "https://codex.top/patricia-tree/"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
 bug-reports:
   "https://github.com/codex-semantics-library/patricia-tree/issues"
 depends: [

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -15,7 +15,7 @@ bug-reports:
   "https://github.com/codex-semantics-library/patricia-tree/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "2.7"}
+  "dune" {>= "3.8"}
   "qcheck-core" {>= "0.21.2" & with-test}
   "ppx_inline_test" {>= "v0.16.0" & with-test}
   "odoc" {>= "2.4.0" & with-doc}

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -15,9 +15,10 @@ bug-reports:
   "https://github.com/codex-semantics-library/patricia-tree/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "3.8"}
+  "dune" {>= "3.0"}
   "qcheck-core" {>= "0.21.2" & with-test}
   "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
   "odoc" {>= "2.4.0" & with-doc}
   "sherlodoc" {with-doc}
 ]

--- a/patriciaTree.ml
+++ b/patriciaTree.ml
@@ -1150,7 +1150,7 @@ module MakeCustomHeterogeneousMap
           if (branching_bit land searched == 0)
           then search (NODE.view tree0)
           else search (NODE.view tree1)
-        | Empty -> assert false (* We already saw that tb is not empty. *)
+        | Empty -> false (* Can only happen on weak nodes. *)
       in search viewb
     | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
       Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
@@ -1526,9 +1526,6 @@ module MakeCustomHeterogeneousMap
           let acc = fold fright tb acc in
           let acc = fold fleft ta acc in
           acc
-  ;;
-
-
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -937,23 +937,23 @@ module type MAP_WITH_VALUE = sig
   (** Test if a map is empty; O(1) complexity. *)
 
   val unsigned_min_binding : 'a t -> (key * 'a value)
-  (** Returns the (key,value) where [Key.to_int key] is minimal (in the
+  (** Returns the [(key,value)] pair where [Key.to_int key] is minimal (in the
       {{!unsigned_lt}unsigned representation} of integers); O(log n) complexity.
-      @raises Not_found if the map is empty *)
+      @raises Not_found if the map is empty. *)
 
   val unsigned_max_binding : 'a t -> (key * 'a value)
-  (** Returns the (key,value) where [Key.to_int key] is maximal (in the
+  (** Returns the [(key,value)] pair where [Key.to_int key] is maximal (in the
       {{!unsigned_lt}unsigned representation} of integers); O(log n) complexity.
-      @raises Not_found if the map is empty *)
+      @raises Not_found if the map is empty. *)
 
   val singleton : key -> 'a value -> 'a t
   (** [singleton key value] creates a map with a single binding, O(1) complexity.  *)
 
   val cardinal : 'a t -> int
-  (** The size of the map. O(n) complexity *)
+  (** The size of the map. O(n) complexity. *)
 
   val is_singleton : 'a t -> (key * 'a value) option
-  (** [is_singleton m] is [Some (k,v)] iff [m] is [singleton k v] *)
+  (** [is_singleton m] is [Some (k,v)] iff [m] is [singleton k v]. *)
 
   val find : key -> 'a t -> 'a value
   (** Return an element in the map, or raise [Not_found], O(log(n)) complexity. *)
@@ -962,7 +962,8 @@ module type MAP_WITH_VALUE = sig
   (** Return an element in the map, or [None], O(log(n)) complexity. *)
 
   val mem : key -> 'a t -> bool
-  (** [mem key map] returns [true] iff [key] is bound in [map], O(log(n)) complexity. *)
+  (** [mem key map] returns [true] if and only if [key] is bound in [map].
+      O(log(n)) complexity. *)
 
   val remove : key -> 'a t -> 'a t
   (** Returns a map with the element removed, O(log(n)) complexity.
@@ -1006,13 +1007,14 @@ module type MAP_WITH_VALUE = sig
       - submap of [map] whose keys are smaller than [key]
       - value associated to [key] (if present)
       - submap of [map] whose keys are bigger than [key]
-      Using the {{!unsigned_lt}unsigned order} is given by {!KEY.to_int}. *)
+
+      Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
   val iter : (key -> 'a value -> unit) -> 'a t -> unit
-  (** Iterate on each (key,value) pair of the map, in increasing {{!unsigned_lt}unsigned order} of keys. *)
+  (** Iterate on each [(key,value)] pair of the map, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val fold : (key -> 'a value -> 'acc -> 'acc) ->  'a t -> 'acc -> 'acc
-  (** Fold on each (key,value) pair of the map, in increasing {{!unsigned_lt}unsigned order} of keys. *)
+  (** Fold on each [(key,value)] pair of the map, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val fold_on_nonequal_inter : (key -> 'a value -> 'a value -> 'acc -> 'acc) ->
     'a t -> 'a t -> 'acc -> 'acc
@@ -1033,11 +1035,11 @@ module type MAP_WITH_VALUE = sig
 
   val filter : (key -> 'a value -> bool) -> 'a t -> 'a t
   (** Returns the submap containing only the key->value pairs satisfying the
-      given predicate. [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      given predicate. [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val for_all : (key -> 'a value -> bool) -> 'a t -> bool
   (** Returns true if the predicate holds on all map bindings. Short-circuiting.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   (** In the following, the *no_share function allows taking arguments
       of different types (but cannot share subtrees of the map), while
@@ -1051,12 +1053,12 @@ module type MAP_WITH_VALUE = sig
       value is physically the same (i.e. [f key value == value] for
       all the keys in the subtree) are guaranteed to be physically
       equal to the original subtree. O(n) complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val map_no_share : ('a value -> 'b value) -> 'a t -> 'b t
   (** [map_no_share f m] returns a map where the [value] bound to each
       [key] is replaced by [f value]. O(n) complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val mapi : (key -> 'a value -> 'a value) -> 'a t -> 'a t
   (** [mapi f m] returns a map where the [value] bound to each [key] is
@@ -1064,12 +1066,12 @@ module type MAP_WITH_VALUE = sig
       value is physically the same (i.e. [f key value == value] for
       all the keys in the subtree) are guaranteed to be physically
       equal to the original subtree. O(n) complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val mapi_no_share : (key -> 'a value -> 'b value) -> 'a t -> 'b t
   (** [mapi_no_share f m] returns a map where the [value] bound to each
       [key] is replaced by [f key value]. O(n) complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val filter_map : (key -> 'a value -> 'a value option) -> 'a t -> 'a t
   (** [filter_map m f] returns a map where the [value] bound to each
@@ -1079,14 +1081,14 @@ module type MAP_WITH_VALUE = sig
       (i.e. [f key value = Some v] with [value == v] for all the keys
       in the subtree) are guaranteed to be physically equal to the
       original subtree. O(n) complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val filter_map_no_share : (key -> 'a value -> 'b value option) -> 'a t -> 'b t
   (** [filter_map m f] returns a map where the [value] bound to each
       [key] is removed (if [f key value] returns [None]), or is
       replaced by [v] ((if [f key value] returns [Some v]). O(n)
       complexity.
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys. *)
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
 
   (** {3 Operations on pairs of maps} *)
@@ -1108,10 +1110,10 @@ module type MAP_WITH_VALUE = sig
       operations. *)
 
   val reflexive_same_domain_for_all2 : (key -> 'a value -> 'a value -> bool) -> 'a t -> 'a t ->  bool
-  (** [reflexive_same_domain_for_all2 f map1 map2] returns true if
+  (** [reflexive_same_domain_for_all2 f map1 map2] returns [true] if
       [map1] and [map2] have the same keys, and [f key value1 value2]
       returns true for each mapping pair of keys. We assume that [f]
-      is reflexive (i.e. [f key value value] returns true) to avoid
+      is reflexive (i.e. [f key value value] returns [true]) to avoid
       visiting physically equal subtrees of [map1] and [map2]. The
       complexity is O(log(n)*Delta) where Delta is the number of
       different keys between [map1] and [map2]. *)
@@ -1141,7 +1143,7 @@ module type MAP_WITH_VALUE = sig
       preserve physical equality of the subtreess in that case.  The
       complexity is O(log(n)*Delta) where Delta is the number of
       different keys between [map1] and [map2].
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys.
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       [f] is never called on physically equal values. *)
 
   val idempotent_inter : (key -> 'a value -> 'a value -> 'a value) -> 'a t -> 'a t -> 'a t
@@ -1153,7 +1155,7 @@ module type MAP_WITH_VALUE = sig
       preserve physical equality of the subtrees in that case.  The
       complexity is O(log(n)*Delta) where Delta is the number of
       different keys between [map1] and [map2].
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys.
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}!.
       [f] is never called on physically equal values. *)
 
   val nonidempotent_inter_no_share : (key -> 'a value -> 'b value -> 'c value) -> 'a t -> 'b t -> 'c t
@@ -1163,7 +1165,7 @@ module type MAP_WITH_VALUE = sig
       need to be idempotent, which imply that we have to visit
       physically equal subtrees of [map1] and [map2].  The complexity
       is O(log(n)*min(|map1|,|map2|)).
-      [f] is called in increasing {{!unsigned_lt}unsigned order} of keys.
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       [f] is called on every shared binding. *)
 
   val idempotent_inter_filter : (key -> 'a value -> 'a value -> 'a value option) -> 'a t -> 'a t -> 'a t

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -1474,8 +1474,8 @@ module type HASHED_VALUE = sig
          {[
             type any = Any : 'a HMap.t -> any
             module MapOfMaps = MakeMap(struct
-              type t = Any : 'a HMap.t -> t
-              let to_int (Any x) = Node.to_int x
+              type t = any
+              let to_int (Any x) = HMap.to_int x
             end)
          ]}
          Using this can lead to unexpected behaviors:

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -928,7 +928,7 @@ module type MAP_WITH_VALUE = sig
     and type _ key = key
     and type ('a,'b) value = ('a,'b value) snd
 
-  (** {3 Basice functions} *)
+  (** {3 Basic functions} *)
 
   val empty : 'a t
   (** The empty map. *)

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -395,7 +395,7 @@ module type BASE_MAP = sig
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of [Key.to_int]. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
 
   type ('acc,'map) polyfold2_union = { f: 'a. 'a key -> ('a,'map) value option -> ('a,'map) value option -> 'acc -> 'acc } [@@unboxed]
@@ -405,7 +405,7 @@ module type BASE_MAP = sig
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exists in either map ([m1 ∪ m2]) whose values are physically
       different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of [Key.to_int]. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   val filter : 'map polypredicate -> 'map t -> 'map t
@@ -1042,7 +1042,7 @@ module type MAP_WITH_VALUE = sig
       [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of [Key.to_int]. *)
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val fold_on_nonequal_union: (key -> 'a value option -> 'a value option -> 'acc -> 'acc) ->
     'a t -> 'a t -> 'acc -> 'acc
@@ -1051,7 +1051,7 @@ module type MAP_WITH_VALUE = sig
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exists in either map ([m1 ∪ m2]) whose values are physically
       different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of [Key.to_int]. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val filter : (key -> 'a value -> bool) -> 'a t -> 'a t
   (** Returns the submap containing only the key->value pairs satisfying the

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -37,7 +37,7 @@
       i.e. it is a space-efficient prefix trie over the big-endian representation of
       the key's integer identifier.
 
-      Example 5-bit patricia tree containing five numbers: 0 [0b0000], 1 [0b0001],
+      Example of a 5-bit patricia tree containing five numbers: 0 [0b0000], 1 [0b0001],
       5 [0b0101] and 7 [0b0111] and -8 [0b1111]:
       {v
                               Branch
@@ -52,7 +52,6 @@
       Leaf(0)  Leaf(1)    Leaf(5)  Leaf(7)
       0b0000   0b0001     0b0101   0b0111
       v}
-
 
       The main benefit of Patricia Tree is that their representation
       is stable (contrary to maps, inserting nodes in any order will
@@ -472,9 +471,10 @@ module type BASE_MAP = sig
 
       It is useful to implement equality on maps:
       {[
-        let equal m1 m2 = MyMap.reflexive_same_domain_for_all2
+        # let equal m1 m2 = MyMap.reflexive_same_domain_for_all2
           { f = fun _ v1 v2 -> MyValue.equal v1 v2}
-          m1 m2
+          m1 m2;;
+        val equal : 'a MyMap.t -> 'a MyMap.t -> bool = <fun>
       ]}
       *)
 

--- a/patriciaTree.mli
+++ b/patriciaTree.mli
@@ -264,7 +264,7 @@ module type HASH_CONSED_NODE = sig
   (** Constant time equality using the {{!hash_consed}hash-consed} nodes identifiers.
       This is equivalent to physical equality.
       Two nodes are equal if their trees contain the same bindings,
-      where keys are compare by {!KEY.to_int} and values are compared by
+      where keys are compared by {!KEY.to_int} and values are compared by
       {!HASHED_VALUE.polyeq}. *)
 
   val compare : 'a t -> 'a t -> int
@@ -1653,7 +1653,7 @@ module MakeCustomHeterogeneousSet
     if so they return it, else they return a new node with a new number.
     With this unique numbering:
     - [equal] and [compare] become constant time operations;
-    - two maps with the same bindings (where keys compared by {!KEY.to_int} and
+    - two maps with the same bindings (where keys are compared by {!KEY.to_int} and
       values by {!HASHED_VALUE.polyeq}) will always be physically equal;
     - functions that benefit from sharing, like {!BASE_MAP.idempotent_union} and
       {!BASE_MAP.idempotent_inter} will see improved performance;
@@ -1694,7 +1694,7 @@ module MakeHashconsedMap(Key: KEY)(Value: HASHED_VALUE)() : sig
   (** Constant time equality using the {{!hash_consed}hash-consed} nodes identifiers.
       This is equivalent to physical equality.
       Two nodes are equal if their trees contain the same bindings,
-      where keys are compare by {!KEY.to_int} and values are compared by
+      where keys are compared by {!KEY.to_int} and values are compared by
       {!HASHED_VALUE.polyeq}. *)
 
   val compare : 'a t -> 'a t -> int
@@ -1729,7 +1729,7 @@ module MakeHashconsedSet(Key: KEY)() : sig
   (** Constant time equality using the {{!hash_consed}hash-consed} nodes identifiers.
       This is equivalent to physical equality.
       Two nodes are equal if their trees contain the same bindings,
-      where keys are compare by {!KEY.to_int} and values are compared by
+      where keys are compared by {!KEY.to_int} and values are compared by
       {!HASHED_VALUE.polyeq}. *)
 
   val compare : t -> t -> int
@@ -1764,7 +1764,7 @@ module MakeHashconsedHeterogeneousSet(Key: HETEROGENEOUS_KEY)() : sig
   (** Constant time equality using the {{!hash_consed}hash-consed} nodes identifiers.
       This is equivalent to physical equality.
       Two nodes are equal if their trees contain the same bindings,
-      where keys are compare by {!KEY.to_int} and values are compared by
+      where keys are compared by {!KEY.to_int} and values are compared by
       {!HASHED_VALUE.polyeq}. *)
 
   val compare : t -> t -> int
@@ -1801,7 +1801,7 @@ module MakeHashconsedHeterogeneousMap(Key: HETEROGENEOUS_KEY)(Value: HETEROGENEO
   (** Constant time equality using the {{!hash_consed}hash-consed} nodes identifiers.
       This is equivalent to physical equality.
       Two nodes are equal if their trees contain the same bindings,
-      where keys are compare by {!KEY.to_int} and values are compared by
+      where keys are compared by {!KEY.to_int} and values are compared by
       {!HASHED_VALUE.polyeq}. *)
 
   val compare : 'a t -> 'a t -> int


### PR DESCRIPTION
To merge after #1. Use mdx to check documentation code.
- Uses mdx to run code in documentation code blocks (in `index.mld` and `PatriciaTree.mli`) and check output
- Fix a bug where `reflexive_subset_domain_forall2` could raise an `assert false` on Weak Maps.
- Also run the CI on macos (it fails on windows though)
- Some typos in documentation were fixed