### PR TITLE
Map difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.11.0 - Unreleased
 
-No public changes yet, but internal refactors.
+- Add `difference`, `domain_difference` and `diff` functions
+- Internal refactor.
 
 # v0.10.0 - 2024-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.11.0 - Unreleased
 
-- Add `difference`, `domain_difference` and `diff` functions
+- Add `difference` and `symmetric_difference` function to maps (and add `difference` to `WithForeign`)
+- Add `diff` functions to sets
 - Internal refactor.
 
 # v0.10.0 - 2024-06-01

--- a/src/PatriciaTree.mli
+++ b/src/PatriciaTree.mli
@@ -87,8 +87,9 @@
       The main benefit of Patricia Tree is that their representation
       is stable (contrary to maps, inserting nodes in any order will
       return the same shape), which allows different versions of a map
-      to share more subtrees in memory, and the operations over two
-      maps to benefit from this sharing. The functions in this library
+      to share more subtrees in memory, and the
+      {{!BASE_MAP.functions_on_pairs}operations over two maps}
+      to benefit from this sharing. The functions in this library
       attempt to maximally preserve sharing and benefit from sharing,
       allowing very important improvements in complexity and running
       time when combining maps or sets is a frequent operation.}

--- a/src/PatriciaTree.mli
+++ b/src/PatriciaTree.mli
@@ -44,12 +44,12 @@
         {td {!MakeHeterogeneousSet}}
       }
       {tr
-        {th {{!hash_consed}hashconsed} Homogeneous}
+        {th {{!hash_consed}Hash-consed} Homogeneous}
         {td {!MakeHashconsedMap}}
         {td {!MakeHashconsedSet}}
       }
       {tr
-        {th {{!hash_consed}Hashconsed} Heterogeneous}
+        {th {{!hash_consed}Hash-consed} Heterogeneous}
         {td {!MakeHashconsedHeterogeneousMap}}
         {td {!MakeHashconsedHeterogeneousSet}}
       }

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1070,6 +1070,7 @@ module MakeCustomHeterogeneousSet
 
   let equal t1 t2 = BaseMap.reflexive_same_domain_for_all2 {f=fun _ _ _ -> true} t1 t2
   let subset t1 t2 = BaseMap.reflexive_subset_domain_for_all2 {f=fun _ _ _ -> true} t1 t2
+  let diff = BaseMap.domain_difference
 
   let split k m = let (l, present, r) = BaseMap.split k m in
     (l, Option.is_some present, r)
@@ -1237,7 +1238,6 @@ module MakeCustomSet
   let is_singleton m = match BaseMap.is_singleton m with
     | None -> None
     | Some(KeyValue(k,())) -> Some k
-
   let unsigned_min_elt t = let Any x = unsigned_min_elt t in x
   let unsigned_max_elt t = let Any x = unsigned_max_elt t in x
   let pop_unsigned_minimum t = Option.map (fun (Any x, t) -> (x,t)) (pop_unsigned_minimum t)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1162,6 +1162,7 @@ module MakeCustomMap
   let reflexive_subset_domain_for_all2 (f: key -> 'a value -> 'a value -> bool) a b =
     BaseMap.reflexive_subset_domain_for_all2 {f=fun k (Snd v1) (Snd v2) -> f k v1 v2} a b
   let slow_merge (f : key -> 'a value option -> 'b value option -> 'c value option) a b = BaseMap.slow_merge {f=fun k v1 v2 -> snd_opt (f k (opt_snd v1) (opt_snd v2))} a b
+  let difference (f: key -> 'a value -> 'a value -> 'a value option) a b = BaseMap.difference {f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2)} a b
   let iter (f: key -> 'a value -> unit) a = BaseMap.iter {f=fun k (Snd v) -> f k v} a
   let fold (f: key -> 'a value -> 'acc -> 'acc) m acc = BaseMap.fold {f=fun k (Snd v) acc -> f k v acc} m acc
   let fold_on_nonequal_inter (f: key -> 'a value -> 'a value -> 'acc -> 'acc) ma mb acc =

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -619,20 +619,20 @@ module MakeCustomHeterogeneousMap
       | _, Empty -> ta
       | Leaf{key;value},_ ->
         (try let res = find key tb in
-            if res == value then remove key ta else
-            match (f.f key value res) with
-            | Some v when v == res -> ta
-            | Some v -> add key v ta
-            | None -> remove key ta
-          with Not_found -> add key value ta)
-      | _,Leaf{key;value} ->
-        (try let res = find key ta in
             if res == value then remove key tb else
-            match f.f key res value with
+            match (f.f key value res) with
             | Some v when v == res -> tb
             | Some v -> add key v tb
             | None -> remove key tb
           with Not_found -> add key value tb)
+      | _,Leaf{key;value} ->
+        (try let res = find key ta in
+            if res == value then remove key ta else
+            match f.f key res value with
+            | Some v when v == res -> ta
+            | Some v -> add key v ta
+            | None -> remove key ta
+          with Not_found -> add key value ta)
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
         if ma == mb && pa == pb

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -641,7 +641,6 @@ module MakeCustomHeterogeneousMap
           let tree0 = difference f ta0 tb0 in
           let tree1 = difference f ta1 tb1 in
           branch ~prefix:pa ~branching_bit:ma ~tree0 ~tree1
-
         else if branches_before pa ma pb mb
         then if (ma :> int) land (pb :> int) == 0
           then branch ~prefix:pa ~branching_bit:ma ~tree0:(difference f ta0 tb) ~tree1:ta1
@@ -654,14 +653,12 @@ module MakeCustomHeterogeneousMap
 
   let rec domain_difference ta tb =
       match NODE.view ta, NODE.view tb with
-      | Empty, _
-      | _, Empty -> ta
-      | Leaf{key;_},_ -> (if mem key tb then empty else ta)
+      | Empty, _ | _, Empty -> ta
+      | Leaf{key;_},_ -> if mem key tb then empty else ta
       | _,Leaf{key;_} -> remove key ta
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
-        if ma == mb && pa == pb
-        then
+        if ma == mb && pa == pb then
           let tree0 = domain_difference ta0 tb0 in
           let tree1 = domain_difference ta1 tb1 in
           branch ~prefix:pa ~branching_bit:ma ~tree0 ~tree1

--- a/src/index.mld
+++ b/src/index.mld
@@ -53,7 +53,7 @@ See the {{!examples}examples} to jump right into using this library.
 {li The Patricia Tree representation is stable, contrary to maps, inserting nodes
   in any order will return the same shape.
   This allows different versions of a map to share more subtrees in memory, and
-  the operations over two maps to benefit from this sharing. The functions in
+  the {{!PatriciaTree.BASE_MAP.functions_on_pairs}operations over two maps} to benefit from this sharing. The functions in
   this library attempt to {b maximally preserve sharing and benefit from sharing},
   allowing very important improvements in complexity and running time when
   combining maps or sets is a frequent operation.

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -433,7 +433,7 @@ module type BASE_MAP = sig
         | {{!idempotent_inter}[idempotent_inter f m1 m2]} |    | [y] | [f c z u] |   |
         | {{!idempotent_inter_filter}[idempotent_inter_filter f m1 m2]}{^ \[1\]} |    | [y] | [f c z u] |   |
         | {{!nonidempotent_inter_no_share}[nonidempotent_inter_no_share f m1 m2]} |    | [f b y y] | [f c z u] |   |
-        | {{!difference}[difference f m1 m2]}{^ \[1\]} | [x] | [f b y y] | [f c z u] |   |
+        | {{!difference}[difference f m1 m2]}{^ \[1\]} | [x] |  | [f c z u] |   |
         | {{!symmetric_difference}[symmetric_difference f m1 m2]}{^ \[1\]} | [x] |  | [f c z u] | [v] |
       }
       {b \[1\]}: Here [f] returns an optional value, returning [None] removes the binding.
@@ -506,17 +506,17 @@ module type BASE_MAP = sig
 
       @since 0.11.0 *)
 
-  val difference: ('a, 'b) polydifference -> 'a t -> 'b t -> 'a t
+  val difference: ('a, 'a) polydifference -> 'a t -> 'a t -> 'a t
   (** [difference f map1 map2] returns the map containing the bindings of [map1]
       that aren't in [map2]. For keys present in both maps but with different
       values, [f.f] is called. If it returns [Some v], then binding [k,v] is kept,
       else [k] is dropped.
 
+      {b Assumes} [f.f] is [None] on the diagonal: [f.f k v v = None].
       [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      [f.f] is never called on physically equal values.
 
       @since 0.11.0 *)
-
-
 
   (** {1 Conversion functions} *)
 
@@ -604,8 +604,8 @@ module type HETEROGENEOUS_MAP = sig
 
         [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
-        This is the same as {!BASE_MAP.difference}
-        but allows the second map to be of a different type.
+        This is the same as {!BASE_MAP.difference} but allows the second map to
+        be of a different type.
 
         @since 0.11.0 *)
   end
@@ -1225,13 +1225,14 @@ module type MAP_WITH_VALUE = sig
 
       @since 0.11.0 *)
 
-  val difference: (key -> 'a value -> 'b value -> 'a value option) -> 'a t -> 'b t -> 'a t
+  val difference: (key -> 'a value -> 'a value -> 'a value option) -> 'a t -> 'a t -> 'a t
   (** [difference f map1 map2] returns a map comprising of the bindings
       of [map1] which aren't in [map2]. For keys present in both maps but with different
       values, [f] is called. If it returns [Some v], then binding [k,v] is kept,
       else [k] is dropped.
 
-      [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      {b Assumes} [f] is none on equal values (i.e. [f key value value == None])
+      [f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since 0.11.0 *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -428,8 +428,9 @@ module type BASE_MAP = sig
   val slow_merge : ('map1, 'map2, 'map3) polymerge -> 'map1 t -> 'map2 t -> 'map3 t
   (** This is the same as {{: https://ocaml.org/api/Map.S.html#VALmerge}Stdlib.Map.S.merge} *)
 
-  val difference: ('a, 'a, 'a) polyinterfilter -> 'a t -> 'a t -> 'a t
-  (** [difference f map1 map2] returns a map comprising of the bindings
+  type ('a, 'b) polydifference = ('a, 'b, 'a) polyinterfilter
+  val symmetric_difference: ('a, 'a) polydifference -> 'a t -> 'a t -> 'a t
+  (** [symmetric_difference f map1 map2] returns a map comprising of the bindings
       of [map1] that aren't in [map2], and the bindings of [map2] that aren't in [map1].
 
       Bindings that are both in [map1] and [map2], but with non-physically equal values
@@ -445,8 +446,8 @@ module type BASE_MAP = sig
 
       @since 0.11.0 *)
 
-  val domain_difference: 'a t -> 'b t -> 'a t
-  (** [domain_difference map1 map2] returns a map comprising of the bindings
+  val difference: ('a, 'b) polydifference -> 'a t -> 'b t -> 'a t
+  (** [difference map1 map2] returns a map comprising of the bindings
       of [map1] whose keys aren't in [map2]. It it the same as
       [filter (fun k _ -> not (mem k map2)) map1], but faster.
 
@@ -532,9 +533,10 @@ module type HETEROGENEOUS_MAP = sig
         keys in [m_from], it only updates for keys that are both in [m_from] and
         [m_to]. *)
 
-    val domain_difference: 'a t -> 'b Map2.t -> 'a t
-    (** [domain_difference map1 map2], returns the map containing the keys of [map1]
-        that aren't in [map2]. This is the same as {!BASE_MAP.domain_difference}
+    type ('map1, 'map2) polydifference = ('map1,'map2) polyupdate_multiple_inter
+    val difference: ('a,'b) polydifference -> 'a t -> 'b Map2.t -> 'a t
+    (** [difference map1 map2], returns the map containing the keys of [map1]
+        that aren't in [map2]. This is the same as {!BASE_MAP.difference}
         but allows the second map to be of a different type.
 
         @since 0.11.0 *)
@@ -1140,8 +1142,8 @@ module type MAP_WITH_VALUE = sig
       O(|m1|+|m2|). Use one of faster functions above if you can. *)
 
 
-  val difference: (key -> 'a value -> 'a value -> 'a value option) -> 'a t -> 'a t -> 'a t
-  (** [difference f map1 map2] returns a map comprising of the bindings
+  val symmetric_difference: (key -> 'a value -> 'a value -> 'a value option) -> 'a t -> 'a t -> 'a t
+  (** [symmetric_difference f map1 map2] returns a map comprising of the bindings
       of [map1] that aren't in [map2], and the bindings of [map2] that aren't in [map1].
 
       Bindings that are both in [map1] and [map2], but with non-physically equal values
@@ -1157,8 +1159,8 @@ module type MAP_WITH_VALUE = sig
 
       @since 0.11.0 *)
 
-  val domain_difference: 'a t -> 'b t -> 'a t
-  (** [domain_difference map1 map2] returns a map comprising of the bindings
+  val difference: (key -> 'a value -> 'b value -> 'a value option) -> 'a t -> 'b t -> 'a t
+  (** [difference map1 map2] returns a map comprising of the bindings
       of [map1] whose keys aren't in [map2]. It it the same as
       [filter (fun k _ -> not (mem k map2)) map1], but faster.
 
@@ -1200,6 +1202,14 @@ module type MAP_WITH_VALUE = sig
         {!update_multiple_from_foreign}, except that instead of updating for all
         keys in [m_from], it only updates for keys that are both in [m_from] and
         [m_to]. *)
+
+    type ('map1, 'map2) polydifference = ('map1,'map2) polyupdate_multiple_inter
+    val difference: ('a,'b) polydifference -> 'a t -> 'b Map2.t -> 'a t
+    (** [difference map1 map2], returns the map containing the keys of [map1]
+        that aren't in [map2]. This is the same as {!BASE_MAP.difference}
+        but allows the second map to be of a different type.
+
+        @since 0.11.0 *)
   end
 
   val pretty :

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -643,7 +643,7 @@ module type HETEROGENEOUS_SET = sig
   (** Existential wrapper for set elements. *)
   type any_elt = Any : 'a elt -> any_elt
 
-  (** {3 Basic functions} *)
+  (** {1 Basic functions} *)
 
   val empty: t
   (** The empty set *)
@@ -692,7 +692,7 @@ module type HETEROGENEOUS_SET = sig
       if [s] is non empty.
       Uses the {{!unsigned_lt}unsigned order} on elements. *)
 
-  (** {3 Functions on pairs of sets} *)
+  (** {1 Functions on pairs of sets} *)
 
   val union: t -> t -> t
   (** [union a b] is the set union of [a] and [b], i.e. the set containing all
@@ -721,7 +721,7 @@ module type HETEROGENEOUS_SET = sig
   (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2].
       @since 0.11.0 *)
 
-  (** {3 Iterators} *)
+  (** {1 Iterators} *)
 
   type polyiter = { f: 'a. 'a elt -> unit; } [@@unboxed]
   val iter: polyiter -> t -> unit
@@ -748,7 +748,7 @@ module type HETEROGENEOUS_SET = sig
   (** Pretty prints the set, [pp_sep] is called once between each element,
       it defaults to {{: https://v2.ocaml.org/api/Format.html#VALpp_print_cut}[Format.pp_print_cut]} *)
 
-  (** {3 Conversion functions} *)
+  (** {1 Conversion functions} *)
 
   val to_seq : t -> any_elt Seq.t
   (** [to_seq st] iterates the whole set, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int} *)
@@ -793,7 +793,7 @@ module type SET = sig
   type t = unit BaseMap.t
   (** The set type *)
 
-  (** {3 Basic functions}                         *)
+  (** {1 Basic functions}                         *)
 
   val empty: t
   (** The empty set *)
@@ -840,7 +840,7 @@ module type SET = sig
       if [s] is non empty.
       Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  (** {3 Iterators} *)
+  (** {1 Iterators} *)
 
   val iter: (elt -> unit) -> t -> unit
   (** [iter f set] calls [f] on all elements of [set], in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
@@ -870,7 +870,7 @@ module type SET = sig
   (** Pretty prints the set, [pp_sep] is called once between each element,
       it defaults to {{: https://v2.ocaml.org/api/Format.html#VALpp_print_cut}[Format.pp_print_cut]} *)
 
-  (** {3 Functions on pairs of sets} *)
+  (** {1 Functions on pairs of sets} *)
 
   val union: t -> t -> t
   (** [union a b] is the set union of [a] and [b], i.e. the set containing all
@@ -893,7 +893,7 @@ module type SET = sig
   (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2].
       @since 0.11.0 *)
 
-  (** {3 Conversion functions} *)
+  (** {1 Conversion functions} *)
 
   val to_seq : t -> elt Seq.t
   (** [to_seq st] iterates the whole set, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int} *)
@@ -956,7 +956,7 @@ module type MAP_WITH_VALUE = sig
     and type _ key = key
     and type ('a,'b) value = ('a,'b value) snd
 
-  (** {3 Basic functions} *)
+  (** {1 Basic functions} *)
 
   val empty : 'a t
   (** The empty map. *)
@@ -1028,7 +1028,7 @@ module type MAP_WITH_VALUE = sig
       whether the old value existed). O(log(n)) complexity.
       Preserves physical equality if the new value is physically equal to the old. *)
 
-  (** {3 Iterators} *)
+  (** {1 Iterators} *)
 
   val split : key -> 'a t -> 'a t * 'a value option * 'a t
   (** [split key map] splits the map into:
@@ -1119,12 +1119,12 @@ module type MAP_WITH_VALUE = sig
       [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
 
-  (** {3 Operations on pairs of maps} *)
+  (** {1 Operations on pairs of maps} *)
   (** See {{!BASE_MAP.functions_on_pairs}the same section for [BASE_MAP]} for
       an overview of what these functions do, and a quick overview of the differences
       between them. *)
 
-  (** {4 Comparing two maps} *)
+  (** {2 Comparing two maps} *)
   (** Equality, inclusion and test for disjoint maps. *)
 
   val reflexive_same_domain_for_all2 : (key -> 'a value -> 'a value -> bool) -> 'a t -> 'a t ->  bool
@@ -1155,7 +1155,7 @@ module type MAP_WITH_VALUE = sig
   val disjoint : 'a t -> 'a t -> bool
   (** [disjoint a b] is [true] if and only if [a] and [b] have disjoint domains. *)
 
-  (** {4 Combining two maps} *)
+  (** {2 Combining two maps} *)
   (** Union, intersection, difference...
       See {{!BASE_MAP.combining_maps}the same section in [BASE_MAP]} for a table showcasing
       the differences between them. *)
@@ -1293,7 +1293,7 @@ module type MAP_WITH_VALUE = sig
   (** Pretty prints all bindings of the map.
       [pp_sep] is called once between each binding pair and defaults to {{: https://v2.ocaml.org/api/Format.html#VALpp_print_cut}[Format.pp_print_cut]}. *)
 
-  (** {3 Conversion functions} *)
+  (** {1 Conversion functions} *)
 
   val to_seq : 'a t -> (key * 'a value) Seq.t
   (** [to_seq m] iterates the whole map, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int} *)

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -531,6 +531,11 @@ module type HETEROGENEOUS_MAP = sig
         {!update_multiple_from_foreign}, except that instead of updating for all
         keys in [m_from], it only updates for keys that are both in [m_from] and
         [m_to]. *)
+
+    val domain_difference: 'a t -> 'b Map2.t -> 'a t
+    (** [domain_difference map1 map2], returns the map containing the keys of [map1]
+        that aren't in [map2]. This is the same as {!BASE_MAP.domain_difference}
+        but allows the second map to be of a different type. *)
   end
 end
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -535,7 +535,9 @@ module type HETEROGENEOUS_MAP = sig
     val domain_difference: 'a t -> 'b Map2.t -> 'a t
     (** [domain_difference map1 map2], returns the map containing the keys of [map1]
         that aren't in [map2]. This is the same as {!BASE_MAP.domain_difference}
-        but allows the second map to be of a different type. *)
+        but allows the second map to be of a different type.
+
+        @since 0.11.0 *)
   end
 end
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -447,9 +447,12 @@ module type BASE_MAP = sig
       @since 0.11.0 *)
 
   val difference: ('a, 'b) polydifference -> 'a t -> 'b t -> 'a t
-  (** [difference map1 map2] returns a map comprising of the bindings
-      of [map1] whose keys aren't in [map2]. It it the same as
-      [filter (fun k _ -> not (mem k map2)) map1], but faster.
+  (** [difference f map1 map2] returns the map containing the bindings of [map1]
+      that aren't in [map2]. For keys present in both maps but with different
+      values, [f.f] is called. If it returns [Some v], then binding [k,v] is kept,
+      else [k] is dropped.
+
+      [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since 0.11.0 *)
 
@@ -535,8 +538,14 @@ module type HETEROGENEOUS_MAP = sig
 
     type ('map1, 'map2) polydifference = ('map1,'map2) polyupdate_multiple_inter
     val difference: ('a,'b) polydifference -> 'a t -> 'b Map2.t -> 'a t
-    (** [difference map1 map2], returns the map containing the keys of [map1]
-        that aren't in [map2]. This is the same as {!BASE_MAP.difference}
+    (** [difference f map1 map2] returns the map containing the bindings of [map1]
+        that aren't in [map2]. For keys present in both maps but with different
+        values, [f.f] is called. If it returns [Some v], then binding [k,v] is kept,
+        else [k] is dropped.
+
+        [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+        This is the same as {!BASE_MAP.difference}
         but allows the second map to be of a different type.
 
         @since 0.11.0 *)
@@ -1160,9 +1169,12 @@ module type MAP_WITH_VALUE = sig
       @since 0.11.0 *)
 
   val difference: (key -> 'a value -> 'b value -> 'a value option) -> 'a t -> 'b t -> 'a t
-  (** [difference map1 map2] returns a map comprising of the bindings
-      of [map1] whose keys aren't in [map2]. It it the same as
-      [filter (fun k _ -> not (mem k map2)) map1], but faster.
+  (** [difference f map1 map2] returns a map comprising of the bindings
+      of [map1] which aren't in [map2]. For keys present in both maps but with different
+      values, [f] is called. If it returns [Some v], then binding [k,v] is kept,
+      else [k] is dropped.
+
+      [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since 0.11.0 *)
 
@@ -1205,9 +1217,14 @@ module type MAP_WITH_VALUE = sig
 
     type ('map1, 'map2) polydifference = ('map1,'map2) polyupdate_multiple_inter
     val difference: ('a,'b) polydifference -> 'a t -> 'b Map2.t -> 'a t
-    (** [difference map1 map2], returns the map containing the keys of [map1]
-        that aren't in [map2]. This is the same as {!BASE_MAP.difference}
-        but allows the second map to be of a different type.
+    (** [difference f map1 map2] returns the map containing the bindings of [map1]
+        that aren't in [map2]. For keys present in both maps but with different
+        values, [f.f] is called. If it returns [Some v], then binding [k,v] is kept,
+        else [k] is dropped.
+
+        [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+        This is the same as {!MAP_WITH_VALUE.difference}, but allows the second
+        map to be of a different type.
 
         @since 0.11.0 *)
   end

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -403,7 +403,7 @@ module type BASE_MAP = sig
       intersection of the keys of [map1] and [map2]. [f.f] is used to combine
       the values a key is mapped in both maps.
 
-      {b Assumes} [f.f] idempotent (i.e. [f key value value == value])
+      {b Assumes} [f.f] idempotent (i.e. [f.f key value value == value])
       [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       [f.f] is never called on physically equal values.
       Preserves physical equality as much as possible.
@@ -436,7 +436,7 @@ module type BASE_MAP = sig
       are passed to [f.f]. If [f.f] returns [Some v] then [v] is used as the new value,
       otherwise the binding is dropped.
 
-      {b Assumes} [f.f] is none on equal values (i.e. [f key value value == None])
+      {b Assumes} [f.f] is none on equal values (i.e. [f.f key value value == None])
       [f.f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       [f.f] is never called on physically equal values.
 
@@ -646,7 +646,8 @@ module type HETEROGENEOUS_SET = sig
       Uses the {{!unsigned_lt}unsigned order} on elements. *)
 
   val diff: t -> t -> t
-  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2]. *)
+  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2].
+      @since 0.11.0 *)
 
   (** {3 Iterators} *)
 
@@ -817,7 +818,8 @@ module type SET = sig
   (** [subset a b] is [true] if all elements of [a] are also in [b]. *)
 
   val diff: t -> t -> t
-  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2]. *)
+  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2].
+      @since 0.11.0 *)
 
   (** {3 Conversion functions} *)
 
@@ -1134,6 +1136,31 @@ module type MAP_WITH_VALUE = sig
       keys, similarly to the [Map.merge] function.  This funcion has
       to traverse all the bindings in [m1] and [m2]; its complexity is
       O(|m1|+|m2|). Use one of faster functions above if you can. *)
+
+
+  val difference: (key -> 'a value -> 'a value -> 'a value option) -> 'a t -> 'a t -> 'a t
+  (** [difference f map1 map2] returns a map comprising of the bindings
+      of [map1] that aren't in [map2], and the bindings of [map2] that aren't in [map1].
+
+      Bindings that are both in [map1] and [map2], but with non-physically equal values
+      are passed to [f]. If [f] returns [Some v] then [v] is used as the new value,
+      otherwise the binding is dropped.
+
+      {b Assumes} [f] is none on equal values (i.e. [f key value value == None])
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      [f] is never called on physically equal values.
+
+      Complexity is [O(log n + d)] where [n] is the size of the maps, and [d] the
+      size of the difference.
+
+      @since 0.11.0 *)
+
+  val domain_difference: 'a t -> 'b t -> 'a t
+  (** [domain_difference map1 map2] returns a map comprising of the bindings
+      of [map1] whose keys aren't in [map2]. It it the same as
+      [filter (fun k _ -> not (mem k map2)) map1], but faster.
+
+      @since 0.11.0 *)
 
   val disjoint : 'a t -> 'a t -> bool
   (** [disjoint a b] is [true] if and only if [a] and [b] have disjoint domains. *)

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -645,6 +645,9 @@ module type HETEROGENEOUS_SET = sig
       all those greater than [elt], and [present] is [true] if [elt] is in [set].
       Uses the {{!unsigned_lt}unsigned order} on elements. *)
 
+  val diff: t -> t -> t
+  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2]. *)
+
   (** {3 Iterators} *)
 
   type polyiter = { f: 'a. 'a elt -> unit; } [@@unboxed]
@@ -812,6 +815,9 @@ module type SET = sig
 
   val subset : t -> t -> bool
   (** [subset a b] is [true] if all elements of [a] are also in [b]. *)
+
+  val diff: t -> t -> t
+  (** [diff s1 s2] is the set of all elements of [s1] that aren't in [s2]. *)
 
   (** {3 Conversion functions} *)
 

--- a/src/test/patriciaTreeTest.ml
+++ b/src/test/patriciaTreeTest.ml
@@ -226,7 +226,7 @@ module IntMap = struct
         | None, _ | _, None -> None
         | Some a, Some b -> Some (f key a b)) m1 m2
 
-  let difference f m1 m2 =
+  let symmetric_difference f m1 m2 =
     M.merge (fun key a b ->
       match a, b with
       | None, x | x, None -> x
@@ -234,7 +234,7 @@ module IntMap = struct
       | Some a, Some b -> f key a b
       ) m1 m2
 
-  let domain_difference m1 m2 = filter (fun k _ -> not (mem k m2)) m1
+  let difference m1 m2 = filter (fun k _ -> not (mem k m2)) m1
 
   let update_multiple_from_foreign m1 m2 f =
     M.merge (fun key a b ->
@@ -646,14 +646,14 @@ end) = struct
       )
   let () = if Param.test_id then QCheck.Test.check_exn test_id_unique
 
-  let test_difference = QCheck.Test.make ~count:1000 ~name:"difference"
+  let test_difference = QCheck.Test.make ~count:1000 ~name:"symmetric_difference"
     gen (fun x ->
       let (m1,model1,m2,model2) = model_from_gen x in
       let orig_f _ x y = if x=y then None else Some (x+y) in
       let chk_calls = check_increases_and_neq () in
       let f k x y = chk_calls k x y; orig_f k x y in
-      let myres = intmap_of_mymap @@ MyMap.difference f m1 m2 in
-      let modelres = IntMap.difference orig_f model1 model2 in
+      let myres = intmap_of_mymap @@ MyMap.symmetric_difference f m1 m2 in
+      let modelres = IntMap.symmetric_difference orig_f model1 model2 in
       IntMap.equal (=) modelres myres
       (* if not b then
         Format.printf "[%a] diff [%a] is [%a] or [%a]@."
@@ -664,11 +664,11 @@ end) = struct
   let () = QCheck.Test.check_exn test_difference
 
 
-  let test_domain_difference = QCheck.Test.make ~count:1000 ~name:"domain_difference"
+  let test_domain_difference = QCheck.Test.make ~count:1000 ~name:"difference"
     gen (fun x ->
       let (m1,model1,m2,model2) = model_from_gen x in
-      let myres = intmap_of_mymap @@ MyMap.domain_difference m1 m2 in
-      let modelres = IntMap.domain_difference model1 model2 in
+      let myres = intmap_of_mymap @@ MyMap.difference m1 m2 in
+      let modelres = IntMap.difference model1 model2 in
       IntMap.equal (=) modelres myres)
   let () = QCheck.Test.check_exn test_difference
 end


### PR DESCRIPTION
Add two difference functions:
- `domain_difference m1 m2` which is just `m1` restricted to elements that don't appear in `m2`. On set, this is the `Stdlib`'s `diff` function. Also defined for `WithForeign` operations.
- `difference f m1 m2` which returns the set of bindings that differ in `m1` and `m2`, combining bindings present in both with `f`.