### PR TITLE
Bucketed trees

### DIFF
--- a/src/PatriciaTree.mli
+++ b/src/PatriciaTree.mli
@@ -18,7 +18,7 @@
 (*  See the GNU Lesser General Public License version 2.1                 *)
 (*  for more details (enclosed in the file LICENSE).                      *)
 (**************************************************************************)
-
+exception Not_found
 (** Association maps from key to values, and sets, implemented with
     Patricia Trees, allowing fast merge operations by making use of
     physical equality between subtrees; and custom implementation of

--- a/src/PatriciaTree.mli
+++ b/src/PatriciaTree.mli
@@ -18,7 +18,7 @@
 (*  See the GNU Lesser General Public License version 2.1                 *)
 (*  for more details (enclosed in the file LICENSE).                      *)
 (**************************************************************************)
-exception Not_found
+
 (** Association maps from key to values, and sets, implemented with
     Patricia Trees, allowing fast merge operations by making use of
     physical equality between subtrees; and custom implementation of

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1320,6 +1320,9 @@ module MakeBucketedHeterogeneous
   let set = Array.unsafe_set
 
   let empty = Obj.magic (Array.make Buckets.nb_buckets Map.empty)
+  (* This Obj.magic is required to avoid the '_weak type.
+     It is correct as long as we never mutate empty without copying it first. *)
+  let empty : 'a t = empty
 
   let is_empty arr = Array.for_all Map.is_empty arr
   let cardinal arr = Array.fold_left (fun a b -> a + Map.cardinal b) 0 arr

--- a/src/index.mld
+++ b/src/index.mld
@@ -85,11 +85,16 @@ See the {{!examples}examples} to jump right into using this library.
   be extended to store size information in nodes if needed.}
 {li Exposes a common interface ({!type:PatriciaTree.NODE.view}) to allow users to write their own pattern
   matching on the tree structure without depending on the {{!PatriciaTree.NODE}[NODE]} being used.}
-{li Additionally, hashconsed versions of heterogeneous/homogeneous maps/sets are
+{li Additionally, {{!PatriciaTree.section-hash_consed}hashconsed versions of heterogeneous/homogeneous maps/sets} are
   available. These provide constant time equality and comparison, and ensure
   maps/set with the same constants are always physically equal. It comes at the cost
   of a constant overhead in memory usage (at worst, as hash-consing may allow
-  memory gains) and constant time overhead when calling constructors.}}
+  memory gains) and constant time overhead when calling constructors.}
+{li Finally, we allow {{!PatriciaTree.section-bucketed}bucketing maps and sets}.
+  i.e. splitting a large map into [n] smaller ones using a [bucket_id : key -> 0 .. (n-1)]
+  function. This allows some speed-up, especially if you know you will be
+  repeatedly accessing a small bucket.
+}}
 
 {1 Quick overview}
 
@@ -137,6 +142,10 @@ The functors used to build maps and sets are the following:
     create a new hash-table to store the created nodes. Calling a functor
     twice with same arguments will lead to two numbering systems for identifiers,
     and thus the types should not be considered compatible.
+}
+{li Bucketed maps and sets are built on top of any of the previous maps
+  using the {{!PatriciaTree.MakeBucketedHeterogeneous}MakeBucketedHeterogeneous}
+  functor
 }}
 
 {2 Interfaces}

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -1439,6 +1439,23 @@ module type HETEROGENEOUS_KEY = sig
       fast. *)
 end
 
+(** The signature of heterogeneous keys which can be bucketed, i.e. sorted into
+    a small number of buckets.
+
+    @canonical PatriciaTree.HETEROGENEOUS_BUCKETED_KEY *)
+module type HETEROGENEOUS_BUCKETED_KEY = sig
+  include HETEROGENEOUS_KEY (** @inline *)
+
+  val nb_buckets: int
+  (** The total number of buckets,
+      should be striclty positive and relatively small. *)
+
+  val bucket_id: 'a t -> int
+  (** The bucket number of the given key, {b must be between [0] and [nb_buckets-1] inclusive}.
+      Not respecting this constraint will lead to runtime errors, as we use it as
+      an index for [Array.unsafe_get] and [Array.unsafe_set]. *)
+end
+
 (** {1 Values} *)
 (** Functor argument used to specify the value type when building the maps. *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -23,6 +23,27 @@
 
 open Ints
 
+(** Standard names for the types in our maps
+
+    @since 0.11.0
+    @canonical PatriciaTree.MAP_TYPES *)
+module type MAP_TYPES = sig
+  type 'key key
+  (** The type of keys. *)
+
+  type ('key, 'map) value
+  (** The type of value, which depends on the type of the key and the type of the map. *)
+
+  type 'map t
+  (** The type of the map, which is parameterized by a type. *)
+
+  val empty : 'map t
+  (** The empty map *)
+
+  val is_empty: 'map t -> bool
+  (** Check if the map is empty. Should be constant time. *)
+end
+
 (** {1 Nodes} *)
 (** Nodes are the underlying representation used to build a patricia-tree.
     The module type specifies the constructors they must provide, and a common
@@ -40,19 +61,9 @@ module type NODE = sig
 
   (** {2 Types} *)
 
-  type 'key key
-  (** The type of keys. *)
-
-  type ('key, 'map) value
-  (** The type of value, which depends on the type of the key and the type of the map. *)
-
-  type 'map t
-  (** The type of the map, which is parameterized by a type. *)
+  include MAP_TYPES (** @inline *)
 
   (** {2 Constructors: build values} *)
-
-  val empty : 'map t
-  (** The empty map *)
 
   val leaf : 'key key -> ('key, 'map) value -> 'map t
   (** A singleton leaf, similar to {!BASE_MAP.singleton} *)
@@ -94,9 +105,6 @@ module type NODE = sig
           [prefix] followed by 0 at position [branching_bit]). *)
     | Leaf : { key : 'key key; value : ('key, 'map) value; } -> 'map view
     (** A key -> value mapping. *)
-
-  val is_empty: 'map t -> bool
-  (** Check if the map is empty. Should be constant time. *)
 
   val view: 'a t -> 'a view
   (** Convert the map to a view. Should be constant time. *)
@@ -165,37 +173,21 @@ end
 
 (** {2 Base map} *)
 
-(** Base map signature: a generic ['b map] storing bindings
+(** Base map interface: a generic ['b map] storing bindings
     of ['a key] to [('a,'b) values].
-    All maps and set are a variation of this type,
-    sometimes with a simplified interface.
-    - {!HETEROGENEOUS_MAP} is just a {!BASE_MAP} with a functor {!HETEROGENEOUS_MAP.WithForeign}
-      for building operations that operate on two maps of different base types;
-    - {!MAP} specializes the interface for non-generic keys ([key] instead of ['a key]);
-    - {!HETEROGENEOUS_SET} specializes {!BASE_MAP} for sets ([('a,'b) value = unit]) and
-      removes the value argument from most operations;
-    - {!SET} specializes {!HETEROGENEOUS_SET} further by making elements (keys)
-      non-generic ([elt] instead of ['a elt]).
+    This is a stripped-down version of {!BASE_MAP}, which excludes functions
+    that rely too much on the patricia tree shape.
 
-    @canonical PatriciaTree.BASE_MAP *)
-module type BASE_MAP = sig
-  include NODE (** @closed *)
+    @since 0.11.0
+    @canonical PatriciaTree.BASE_MAP_INTERFACE *)
+module type BASE_MAP_INTERFACE = sig
+  include MAP_TYPES (** @closed *)
 
   (** Existential wrapper for the ['a] parameter in a ['a key], [('a,'map) value] pair *)
   type 'map key_value_pair =
       KeyValue : 'a key * ('a, 'map) value -> 'map key_value_pair
 
   (** {1 Basic functions} *)
-
-  val unsigned_min_binding : 'a t -> 'a key_value_pair
-  (** [unsigned_min_binding m] is minimal binding [KeyValue(k,v)] of the map,
-      using the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
-      @raises Not_found if the map is empty *)
-
-  val unsigned_max_binding : 'a t -> 'a key_value_pair
-  (** [unsigned_max_binding m] is maximal binding [KeyValue(k,v)] of the map,
-      using the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
-      @raises Not_found if the map is empty *)
 
   val singleton : 'a key -> ('a, 'b) value -> 'b t
   (** Create a map with a single binding. *)
@@ -220,18 +212,6 @@ module type BASE_MAP = sig
   val remove : 'key key -> 'map t -> 'map t
   (** Returns a map with the element removed, O(log(n)) complexity.
       Returns a physically equal map if the element is absent. *)
-
-  val pop_unsigned_minimum: 'map t -> ('map key_value_pair * 'map t) option
-  (** [pop_unsigned_minimum m] returns [None] if [is_empty m], or [Some(key,value,m')] where
-      [(key,value) = unsigned_min_binding m] and [m' = remove m key].
-      Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
-      O(log(n)) complexity. *)
-
-  val pop_unsigned_maximum: 'map t -> ('map key_value_pair * 'map t) option
-  (** [pop_unsigned_maximum m] returns [None] if [is_empty m], or [Some(key,value,m')] where
-      [(key,value) = unsigned_max_binding m] and [m' = remove m key].
-      Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
-      O(log(n)) complexity. *)
 
   val insert: 'a key -> (('a,'map) value option -> ('a,'map) value) -> 'map t -> 'map t
   (** [insert key f map] modifies or insert an element of the map; [f]
@@ -548,6 +528,53 @@ module type BASE_MAP = sig
 
   val to_list : 'a t -> 'a key_value_pair list
   (** [to_list m] returns the bindings of [m] as a list, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int} *)
+end
+
+(** Base map signature: a generic ['b map] storing bindings
+    of ['a key] to [('a,'b) values].
+    All maps and set are a variation of this type,
+    sometimes with a simplified interface.
+    - {!HETEROGENEOUS_MAP} is just a {!BASE_MAP} with a functor {!HETEROGENEOUS_MAP.WithForeign}
+      for building operations that operate on two maps of different base types;
+    - {!MAP} specializes the interface for non-generic keys ([key] instead of ['a key]);
+    - {!HETEROGENEOUS_SET} specializes {!BASE_MAP} for sets ([('a,'b) value = unit]) and
+      removes the value argument from most operations;
+    - {!SET} specializes {!HETEROGENEOUS_SET} further by making elements (keys)
+      non-generic ([elt] instead of ['a elt]).
+
+    @canonical PatriciaTree.BASE_MAP *)
+module type BASE_MAP = sig
+  include NODE (** @closed *)
+
+  include BASE_MAP_INTERFACE
+    with type 'map t := 'map t
+     and type 'key key := 'key key
+     and type ('key, 'map) value := ('key, 'map) value
+  (** @open *)
+
+  (** {1 Min and Max} *)
+
+  val unsigned_min_binding : 'a t -> 'a key_value_pair
+  (** [unsigned_min_binding m] is minimal binding [KeyValue(k,v)] of the map,
+      using the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
+      @raises Not_found if the map is empty *)
+
+  val unsigned_max_binding : 'a t -> 'a key_value_pair
+  (** [unsigned_max_binding m] is maximal binding [KeyValue(k,v)] of the map,
+      using the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
+      @raises Not_found if the map is empty *)
+
+  val pop_unsigned_minimum: 'map t -> ('map key_value_pair * 'map t) option
+  (** [pop_unsigned_minimum m] returns [None] if [is_empty m], or [Some(key,value,m')] where
+      [(key,value) = unsigned_min_binding m] and [m' = remove m key].
+      Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
+      O(log(n)) complexity. *)
+
+  val pop_unsigned_maximum: 'map t -> ('map key_value_pair * 'map t) option
+  (** [pop_unsigned_maximum m] returns [None] if [is_empty m], or [Some(key,value,m')] where
+      [(key,value) = unsigned_max_binding m] and [m' = remove m key].
+      Uses the {{!unsigned_lt}unsigned order} on {!KEY.to_int}.
+      O(log(n)) complexity. *)
 end
 
 (** {2 Heterogeneous maps and sets} *)
@@ -1437,23 +1464,6 @@ module type HETEROGENEOUS_KEY = sig
   (** Polymorphic equality function used to compare our keys.
       It should satisfy [(to_int a) = (to_int b) ==> polyeq a b = Eq], and be
       fast. *)
-end
-
-(** The signature of heterogeneous keys which can be bucketed, i.e. sorted into
-    a small number of buckets.
-
-    @canonical PatriciaTree.HETEROGENEOUS_BUCKETED_KEY *)
-module type HETEROGENEOUS_BUCKETED_KEY = sig
-  include HETEROGENEOUS_KEY (** @inline *)
-
-  val nb_buckets: int
-  (** The total number of buckets,
-      should be striclty positive and relatively small. *)
-
-  val bucket_id: 'a t -> int
-  (** The bucket number of the given key, {b must be between [0] and [nb_buckets-1] inclusive}.
-      Not respecting this constraint will lead to runtime errors, as we use it as
-      an index for [Array.unsafe_get] and [Array.unsafe_set]. *)
 end
 
 (** {1 Values} *)


### PR DESCRIPTION
This adds generic bucketed maps (split one big map into n smaller ones using a `bucket_id : int -> 0 .. (n-1)` function. This is the trick currently used in codex's nonrelational constraint domain, which we've seen improve performance

This is still a WIP as it needs to support non-heterogeneous maps (and perhaps sets).

Overall I thinks the technique is good but it requires some changes of interface I'm not quite happy with.
- We now need a smaller version of `BASE_MAP`, which I've called `BASE_MAP_INTERFACE` for lack of imagination
- We also need a smaller version of `NODE`, with only the types and no constructors (except empty), which I've called `MAP_TYPES`.
- We'll also probably need smaller versions of `MAP`, `SET` and `HETEROGENEOUS_SET` which remove their `BaseMap` module and the `pop_minimum`/`min_binding` functions