### PR TITLE
idempotent_inter_filter call f on every intersections

### DIFF
--- a/src/functors.ml
+++ b/src/functors.ml
@@ -778,12 +778,10 @@ module MakeCustomHeterogeneousMap
 
   type ('map1,'map2,'map3) polyinterfilter = ('map1, 'map2, 'map3) polyupdate_multiple_inter = { f: 'a. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> ('a,'map3) Value.t option } [@@unboxed]
   let rec idempotent_inter_filter f ta tb =
-    if ta == tb then ta
-    else match NODE.view ta,NODE.view tb with
+    match NODE.view ta,NODE.view tb with
       | Empty, _ | _, Empty -> empty
       | Leaf{key;value},_ ->
         (try let res = find key tb in
-           if res == value then ta else
            match (f.f key value res) with
            | Some v when v == value -> ta
            | Some v -> leaf key v
@@ -791,7 +789,6 @@ module MakeCustomHeterogeneousMap
          with Not_found -> empty)
       | _,Leaf{key;value} ->
         (try let res = find key ta in
-           if res == value then tb else
            match f.f key res value with
            | Some v when v == value -> tb
            | Some v -> leaf key v

--- a/src/index.mld
+++ b/src/index.mld
@@ -246,7 +246,7 @@ Here is a small example of a non-generic map:
     This allows faster than [O(n)] intersections.
   {[
   # let map2 =
-      IMap.idempotent_inter_filter (fun _key _l _r -> None)
+      IMap.idempotent_inter (fun _key l _r -> l)
         (IMap.add 4 "something" map)
         (IMap.add 5 "something else" map);;
   val map2 : string IMap.t = <abstr>

--- a/src/test/patriciaTreeTest.ml
+++ b/src/test/patriciaTreeTest.ml
@@ -544,9 +544,9 @@ end) = struct
             else let res =  sdbm3 key a b in
               if res mod 3 == 0 then None else Some res
           in
-          let chk_calls = check_increases_and_neq () in
+          let chk_calls = check_increases () in
           let myres = intmap_of_mymap @@ MyMap.idempotent_inter_filter
-            (fun k a b -> chk_calls k a b; f k a b) m1 m2 in
+            (fun k a b -> chk_calls k; f k a b) m1 m2 in
           let modelres = IntMap.inter_filter model1 model2 f in
           (* dump_test model1 model2 myres modelres;           *)
           IntMap.equal (=) modelres myres)
@@ -621,7 +621,8 @@ end) = struct
     let map2 = MyMap.add min_int 5 map in
     let map3 = MyMap.add max_int 8 map2 in
     let map4 = MyMap.add 25 8 map2 in
-    let map5 = MyMap.idempotent_inter_filter (fun _ _ _ -> None) map3 map4 in
+    let map5 = MyMap.idempotent_inter_filter (fun _ a _ -> Some a) map3 map4 in
+    let map6 = MyMap.idempotent_inter_filter (fun _ _ _ -> None) map3 map4 in
     (* Format.printf "[%a]@." pp_l (MyMap.to_list  map3);
     Format.printf "[%a]@." pp_l (MyMap.to_list  map4);
     Format.printf "[%a]@." pp_l (MyMap.to_list  map5);
@@ -633,7 +634,8 @@ end) = struct
     MyMap.to_list map2 = [(0,0); (min_int,5)] &&
     MyMap.to_list map3 = [(0,0); (max_int,8); (min_int,5)] &&
     MyMap.to_list map4 = [(0,0); (25,8); (min_int,5)] &&
-    MyMap.to_list map5 = MyMap.to_list map2
+    MyMap.to_list map5 = [(0,0); (min_int,5)] &&
+    MyMap.to_list map6 = []
 
   let test_id_unique = QCheck.Test.make ~count:1000 ~name:"unique_hashcons_id"
   gen (fun (one,two,three) ->


### PR DESCRIPTION
The behavior of `idempotent_inter_filter` is surprising when `f` returns `None`.
This assert fails:
```ocaml
module Intmap = PatriciaTree.MakeMap (struct
  type t = int

  let to_int = Fun.id
end)

let () =
  assert (
    Intmap.is_empty @@
    Intmap.idempotent_inter_filter
      (fun _ _ _ -> None)
      (Intmap.singleton 0 'a')
      (Intmap.singleton 0 'a'))
```

The function `f` is possibly not called on every elements of the intersection, or not called at all depending on the internal shape of the tree. For example, `f` is never called in:

```ocaml
idempotent_inter_filter f tree (add unique_key v tree) == tree
```

The behavior after this change is incompatible with the definition of `idempotent_inter`, which is linked from `idempotent_inter_filter`'s doc and says:

    [f] is never called on physically equal values.

But `idempotent_inter_filter` can also be interpreted as a combination of `idempotent_inter` and `filter` on the intersection. In which case, I'd expect that returning `None` removes an element from the intersection, independently of the internal shape of the tree or of the allocation strategy.
Perhaps a non-idempotent version of the function should be added to avoid the surprise ?
