### PR TITLE
Setup `bisect_ppx`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _build/
 _html/
 .vscode
 headers/
+# bisect_ppx html output
+_coverage/

--- a/dune-project
+++ b/dune-project
@@ -67,6 +67,7 @@
    (and
     (>= "2.4.1")
     :with-test))
+  (bisect_ppx :with-dev)
   (odoc
    (and
     (>= "2.4.0")

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -19,6 +19,7 @@ depends: [
   "qcheck-core" {>= "0.21.2" & with-test}
   "ppx_inline_test" {>= "v0.16.0" & with-test}
   "mdx" {>= "2.4.1" & with-test}
+  "bisect_ppx" {with-dev}
   "odoc" {>= "2.4.0" & with-doc}
   "sherlodoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -21,9 +21,16 @@
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; The library is instrumented with bisect_ppx. To obtain a test coverage
+; report, do:
+;   dune runtest --instrument-with bisect_ppx --force
+;   bisect-ppx-report html
+
 (library
  (name PatriciaTree)
  (public_name patricia-tree)
+ (instrumentation
+  (backend bisect_ppx))
  (foreign_stubs
   (language c)
   (names int_builtins)))


### PR DESCRIPTION
Dune has first class support for `bisect_ppx`, which makes the setup trivial. These commands run the instrumented code and generate the HTML report:

    dune runtest --instrument-with bisect_ppx --force
    bisect-ppx-report html

The coverage report in HTML format can be found at:

    _coverage/index.html

The library is not instrumented and does not depend on bisect_ppx when it's built with a different command than above.

The current coverage is 61.38% for the entire project and 63% for `src/functors.ml`.