### PR TITLE
Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,3 +380,13 @@ There is no imposed coding style for this repository, here are just a few guidel
 - Please document any new functions in the interface, using [ocamldoc style comments](https://v2.ocaml.org/manual/ocamldoc.html#s%3Aocamldoc-comments).
 - Please consider adding test for new features/fixed bugs if at all possible.
   This library uses a [QuickCheck](https://www.ocaml.org/p/quickcheck/latest/doc/QuickCheck/index.html) framework for tests.
+
+To run the tests, do:
+```
+dune runtest
+```
+
+To run the benchmarks, do:
+```
+dune build @bench --force
+```

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,0 +1,175 @@
+open QCheck
+
+(** Calling convention *)
+
+module Intmap = PatriciaTree.MakeMap (struct
+  type t = int
+
+  let to_int = Fun.id
+end)
+
+let intmap_add m (k, v) = Intmap.add k v m
+
+(** Pre-constructed test data. *)
+
+let state = Random.get_state ()
+let array_rand ar = ar.(Gen.int_bound (Array.length ar - 1) state)
+let tree_size = 1000
+let key_value_of_key k = (k, string_of_int k)
+
+(* Number of trees in each dataset. *)
+let trees_count = 20
+let mk_tree = Array.fold_left intmap_add Intmap.empty
+let mk_trees = Array.map mk_tree
+
+let mk_key_values gen =
+  Array.init trees_count (fun _ -> Array.init tree_size gen)
+
+let random_key_values =
+  mk_key_values (fun _ -> key_value_of_key (Gen.int state))
+
+let similar_trees_key_values =
+  let bound = tree_size * 2 in
+  mk_key_values (fun _ -> key_value_of_key (Gen.int_bound bound state))
+
+let ordered_low_key_values = mk_key_values key_value_of_key
+
+let ordered_high_key_values =
+  mk_key_values (fun i -> key_value_of_key (Int.max_int - i))
+
+(* A set of trees with arbitrary keys. *)
+let random_trees = mk_trees random_key_values
+
+(* A set of trees with arbitrary keys and approx 50% of common bindings between
+   them. Trees might be smaller than [tree_size]. *)
+let similar_trees = mk_trees similar_trees_key_values
+
+(* Random subset of trees in [similar_trees] with 50 elements or less. *)
+let small_similar_trees =
+  mk_trees
+    (Array.map
+       (fun kvs -> Array.init 50 (fun _ -> array_rand kvs))
+       similar_trees_key_values)
+
+(* A tree with continuous keys from 0 to [tree_size-1]. *)
+let ordered_low_trees = mk_trees ordered_low_key_values
+let ordered_high_trees = mk_trees ordered_high_key_values
+
+(** Test definitions. *)
+
+open Bechamel
+
+let make_test name call = [ Test.make ~name (Staged.stage @@ call) ]
+
+let make_indexed name ~fmt args call =
+  let f arg = Staged.stage (call arg) in
+  let mk_test (variation_name, dataset) =
+    let name = Format.asprintf fmt name variation_name in
+    Test.make ~name (f dataset)
+  in
+  List.map mk_test args
+
+(** Construction from small positive ordered values. *)
+let t_construct_pos_low_ordered =
+  make_test "Constr: pos, ord, small" @@ fun () ->
+  Array.fold_left intmap_add Intmap.empty (array_rand ordered_low_key_values)
+
+(** Construction from high positive ordered values. *)
+let t_construct_pos_high_ordered =
+  make_test "Constr: pos, ord, large" @@ fun () ->
+  Array.fold_left intmap_add Intmap.empty (array_rand ordered_high_key_values)
+
+(** Construction from ordered keys with a part of random keys. *)
+let t_construct_mixed =
+  let data =
+    let mk_mixed ratio =
+      mk_key_values (fun i ->
+          let i = Option.value ~default:i Gen.(option ~ratio int state) in
+          key_value_of_key i)
+    in
+    [
+      (0, ordered_low_key_values);
+      (1, mk_mixed 0.01);
+      (5, mk_mixed 0.05);
+      (25, mk_mixed 0.25);
+      (100, random_key_values);
+    ]
+  in
+  make_indexed "Constr" ~fmt:"%s: %d%% random" data @@ fun kvs () ->
+  Array.fold_left intmap_add Intmap.empty (array_rand kvs)
+
+(** Test each set operation in several scenarios. *)
+let make_set_op name f =
+  (* Two equal trees except for one element *)
+  let equal_except_one_trees =
+    Array.split
+      (Array.map
+         (fun kvs ->
+           (mk_tree kvs, mk_tree (Array.sub kvs 0 (Array.length kvs - 1))))
+         random_key_values)
+  in
+  let data =
+    [
+      ("random disjoint", (random_trees, random_trees));
+      ("random 50% inter", (similar_trees, similar_trees));
+      ("ordered disjoint", (ordered_low_trees, ordered_high_trees));
+      ("large and small disjoint", (random_trees, small_similar_trees));
+      ("equal except one element", equal_except_one_trees);
+    ]
+  in
+  make_indexed ("Set: " ^ name) ~fmt:"%s (%s)" data
+  @@ fun (trees_l, trees_r) () ->
+  ignore (f (array_rand trees_l) (array_rand trees_r))
+
+(* Left-biased *)
+let t_idempotent_union =
+  make_set_op "idempotent_union" (Intmap.idempotent_union (fun _ a _ -> a))
+
+(* Left-biased *)
+let t_slow_merge =
+  make_set_op "slow_merge"
+    (Intmap.slow_merge (fun _ a b -> if Option.is_none a then b else a))
+
+(* Left-biased *)
+let t_idempotent_inter =
+  make_set_op "idempotent_inter" (Intmap.idempotent_inter (fun _ a _ -> a))
+
+let t_nonidempotent_inter_no_share =
+  make_set_op "nonidempotent_inter_no_share"
+    (Intmap.nonidempotent_inter_no_share (fun _ a _ -> a))
+
+let t_symmetric_difference =
+  make_set_op "symmetric_difference"
+    (Intmap.symmetric_difference (fun _ _ _ -> None))
+
+let t_difference =
+  make_set_op "difference" (Intmap.difference (fun _ _ _ -> None))
+
+let t_reflexive_same_domain_for_all2 =
+  make_set_op "reflexive_same_domain_for_all2"
+    (Intmap.reflexive_same_domain_for_all2 (fun _ a b -> a = b))
+
+let t_nonreflexive_same_domain_for_all2 =
+  make_set_op "nonreflexive_same_domain_for_all2"
+    (Intmap.nonreflexive_same_domain_for_all2 (fun _ a b -> a = b))
+
+let t_reflexive_subset_domain_for_all2 =
+  make_set_op "reflexive_subset_domain_for_all2"
+    (Intmap.reflexive_subset_domain_for_all2 (fun _ a b -> a = b))
+
+let tests =
+  List.concat
+    [
+      t_construct_pos_low_ordered;
+      t_construct_pos_high_ordered;
+      t_construct_mixed;
+      t_idempotent_union;
+      t_slow_merge;
+      t_idempotent_inter;
+      t_nonidempotent_inter_no_share;
+      t_symmetric_difference;
+      t_difference;
+      t_reflexive_same_domain_for_all2;
+      t_nonreflexive_same_domain_for_all2;
+      t_reflexive_subset_domain_for_all2;
+    ]

--- a/bench/dune
+++ b/bench/dune
@@ -2,7 +2,7 @@
  (name main)
  (libraries patricia-tree bechamel qcheck notty.unix bechamel-notty))
 
-; Run with: dune build @bench
+; Run with: dune build @bench --force
 
 (rule
  (alias bench)

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,10 @@
+(executable
+ (name main)
+ (libraries patricia-tree bechamel qcheck notty.unix bechamel-notty))
+
+; Run with: dune build @bench
+
+(rule
+ (alias bench)
+ (action
+  (run ./main.exe)))

--- a/bench/dune
+++ b/bench/dune
@@ -1,10 +1,3 @@
 (executable
  (name main)
- (libraries patricia-tree bechamel qcheck notty.unix bechamel-notty))
-
-; Run with: dune build @bench --force
-
-(rule
- (alias bench)
- (action
-  (run ./main.exe)))
+ (libraries patricia-tree bechamel qcheck csv))

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -29,38 +29,76 @@ let minor_allocated_precise =
 let instances =
   Instance.[ monotonic_clock_us; minor_allocated_precise; promoted ]
 
+let predictors = [| Measure.run |]
+
 let benchmark () =
   let cfg = Benchmark.cfg ~quota:(Time.second 0.33) () in
-  List.map (Benchmark.all cfg instances) Bench.tests
+  List.map
+    (fun t -> (Test.Elt.name t, Benchmark.run cfg instances t))
+    (Test.expand Bench.tests)
 
-let analyze results =
-  let ols =
-    Analyze.ols ~bootstrap:0 ~r_square:true ~predictors:[| Measure.run |]
+(** Analyze the test results using OLS and return the result in a tablular
+    format. *)
+let analyze_to_table ~instances ~bootstrap ~r_square ~predictors :
+    (string * Benchmark.t) list -> string list * (string * float list) list =
+ fun results ->
+  let ols = Analyze.ols ~bootstrap ~r_square ~predictors in
+  let metrics =
+    List.init (Array.length predictors) (fun i -> `Predictor i)
+    @ if r_square then [ `R_square ] else []
   in
-  Analyze.merge ols instances
-    (List.map (fun instance -> Analyze.all ols instance results) instances)
+  let rows =
+    List.map
+      (fun (test_name, results) ->
+        ( test_name,
+          List.concat_map
+            (fun inst ->
+              let ols = Analyze.one ols inst results in
+              let estimates =
+                Option.value ~default:[] (Analyze.OLS.estimates ols)
+              in
+              List.map
+                (function
+                  | `Predictor i ->
+                      Option.value ~default:Float.nan (List.nth_opt estimates i)
+                  | `R_square ->
+                      Option.value ~default:Float.nan (Analyze.OLS.r_square ols))
+                metrics)
+            instances ))
+      results
+  in
+  let header =
+    List.concat_map
+      (fun inst ->
+        let lbl = Measure.label inst and unit = Measure.unit inst in
+        List.map
+          (function
+            | `Predictor i ->
+                Printf.sprintf "%s (%s/%s)" lbl unit predictors.(i)
+            | `R_square -> Printf.sprintf "%s (R²)" lbl)
+          metrics)
+      instances
+  in
+  (header, rows)
 
-let analyze = List.map analyze
+(** Truncated string representation with at most 3 digits after the period. *)
+let nice_float_to_string f =
+  let precision =
+    if f < 100. then if f < 10. then 3 else 2 else if f < 1000. then 1 else 0
+  in
+  Printf.sprintf "%.*f" precision f
+
+let output_csv (header, rows) =
+  let rows =
+    List.map
+      (fun (test_name, data) -> test_name :: List.map nice_float_to_string data)
+      rows
+  in
+  let outf = "results.csv" in
+  Csv.save outf (("Test name" :: header) :: rows);
+  Printf.eprintf "Output saved to %S.\n%!" outf
 
 let () =
-  List.iter
-    (fun instance -> Bechamel_notty.Unit.add instance (Measure.unit instance))
-    instances
-
-let output_notty results =
-  let open Notty_unix in
-  let open Notty in
-  let img window results =
-    Bechamel_notty.Multiple.image_of_ols_results ~rect:window
-      ~predictor:Measure.run results
-  in
-  let window =
-    match winsize Unix.stdout with
-    | Some (w, h) -> { Bechamel_notty.w; h }
-    | None -> { Bechamel_notty.w = 80; h = 1 }
-  in
-  let img = List.map (img window) results |> I.vcat in
-  output_image img;
-  Format.printf "@\n"
-
-let () = benchmark () |> analyze |> output_notty
+  benchmark ()
+  |> analyze_to_table ~instances ~bootstrap:0 ~r_square:false ~predictors
+  |> output_csv

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,0 +1,66 @@
+open Bechamel
+open Toolkit
+
+(** Alternative to [monotonic_clock] that works in µs/run. *)
+let monotonic_clock_us =
+  let module Ext = struct
+    include Monotonic_clock
+
+    let get () = get () /. 1000.
+    let unit () = "µs"
+  end in
+  let ext = Measure.register (module Ext) in
+  Measure.instance (module Ext) ext
+
+let minor_allocated_precise =
+  let module Ext = struct
+    type witness = unit
+
+    let load () = ()
+    let unload () = ()
+    let make () = ()
+    let get () = Gc.minor_words ()
+    let label () = "minor-allocated"
+    let unit () = "word"
+  end in
+  let ext = Measure.register (module Ext) in
+  Measure.instance (module Ext) ext
+
+let instances =
+  Instance.[ monotonic_clock_us; minor_allocated_precise; promoted ]
+
+let benchmark () =
+  let cfg = Benchmark.cfg ~quota:(Time.second 0.33) () in
+  List.map (Benchmark.all cfg instances) Bench.tests
+
+let analyze results =
+  let ols =
+    Analyze.ols ~bootstrap:0 ~r_square:true ~predictors:[| Measure.run |]
+  in
+  Analyze.merge ols instances
+    (List.map (fun instance -> Analyze.all ols instance results) instances)
+
+let analyze = List.map analyze
+
+let () =
+  List.iter
+    (fun instance -> Bechamel_notty.Unit.add instance (Measure.unit instance))
+    instances
+
+let output_notty results =
+  let open Notty_unix in
+  let open Notty in
+  let img window results =
+    Bechamel_notty.Multiple.image_of_ols_results ~rect:window
+      ~predictor:Measure.run results
+  in
+  let window =
+    match winsize Unix.stdout with
+    | Some (w, h) -> { Bechamel_notty.w; h }
+    | None -> { Bechamel_notty.w = 80; h = 1 }
+  in
+  let img = List.map (img window) results |> I.vcat in
+  output_image img;
+  Format.printf "@\n"
+
+let () = benchmark () |> analyze |> output_notty

--- a/dune
+++ b/dune
@@ -1,0 +1,8 @@
+; Run with: dune build @bench --force
+
+(rule
+ (alias bench)
+ (mode promote)
+ (targets results.csv)
+ (action
+  (run bench/main.exe)))

--- a/dune-project
+++ b/dune-project
@@ -74,6 +74,5 @@
   (sherlodoc :with-doc)
   ; Benchmark dependencies
   (bechamel :with-dev)
-  (qcheck :with-dev)
-  (notty :with-dev)
-  (bechamel-notty :with-dev)))
+  (csv :with-dev)
+  (qcheck :with-dev)))

--- a/dune-project
+++ b/dune-project
@@ -71,4 +71,9 @@
    (and
     (>= "2.4.0")
     :with-doc))
-  (sherlodoc :with-doc)))
+  (sherlodoc :with-doc)
+  ; Benchmark dependencies
+  (bechamel :with-dev)
+  (qcheck :with-dev)
+  (notty :with-dev)
+  (bechamel-notty :with-dev)))

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -22,9 +22,8 @@ depends: [
   "odoc" {>= "2.4.0" & with-doc}
   "sherlodoc" {with-doc}
   "bechamel" {with-dev}
+  "csv" {with-dev}
   "qcheck" {with-dev}
-  "notty" {with-dev}
-  "bechamel-notty" {with-dev}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/patricia-tree.opam
+++ b/patricia-tree.opam
@@ -21,6 +21,10 @@ depends: [
   "mdx" {>= "2.4.1" & with-test}
   "odoc" {>= "2.4.0" & with-doc}
   "sherlodoc" {with-doc}
+  "bechamel" {with-dev}
+  "qcheck" {with-dev}
+  "notty" {with-dev}
+  "bechamel-notty" {with-dev}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This adds benchmarks for the API generated by `MakeMap`. They are run with:

    dune build @bench

The construction fonctions and most set operations are measured. The elapsed time and the memory allocations (both allocated and promoted) are measured. The result is printed on the terminal.

Bechamel is used to run the benchmarks, analyse the results and present them on the screen using Notty.
The test data are generated using QCheck.