### PR TITLE
Add nonidempotent_union to maps

### DIFF
--- a/src/functors.ml
+++ b/src/functors.ml
@@ -521,8 +521,8 @@ module MakeCustomHeterogeneousMap
 
   (* Note: Insert is a bit weird, I am not sure it should be exported. *)
   type 'map polyinsert = { f: 'a . key:'a Key.t -> old:('a,'map) Value.t -> value:('a,'map) Value.t -> ('a,'map) Value.t } [@@unboxed]
-  let idempotent_insert_for_union: type a map. map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
-    fun f thekey value t ->
+  let insert_for_union: type a map. idempotent:bool -> map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
+    fun ~idempotent f thekey value t ->
     let thekeyint = Key.to_int thekey in
     (* Preserve physical equality whenever possible. *)
     let exception Unmodified in
@@ -532,7 +532,9 @@ module MakeCustomHeterogeneousMap
         | Leaf{key;value=old} ->
           begin match Key.polyeq key thekey with
             | Eq ->
-              if value == old then raise Unmodified else
+              (* We want to call [f.f] when [value == old] when called from
+                 [nonidempotent_union]. *)
+              if idempotent && value == old then raise Unmodified else
               let newv = f.f ~key ~old ~value in
               if newv == old then raise Unmodified
               else leaf key newv
@@ -548,28 +550,6 @@ module MakeCustomHeterogeneousMap
           else join thekeyint (leaf thekey value) (prefix :> int) t
       in loop t
     with Unmodified -> t
-
-  let nonidempotent_insert_for_union: type a map. map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
-    fun f thekey value t ->
-    let thekeyint = Key.to_int thekey in
-    let rec loop t = match NODE.view t with
-      | Empty -> leaf thekey value
-      | Leaf{key;value=old} ->
-        begin match Key.polyeq key thekey with
-          | Eq ->
-            let newv = f.f ~key ~old ~value in
-            leaf key newv
-          | Diff ->
-            let keyint = (Key.to_int key) in
-            join thekeyint (leaf thekey value) keyint t
-        end
-      | Branch{prefix;branching_bit;tree0;tree1} ->
-        if match_prefix thekeyint prefix branching_bit then
-          if (thekeyint land (branching_bit :> int)) == 0
-          then branch ~prefix ~branching_bit ~tree0:(loop tree0) ~tree1
-          else branch ~prefix ~branching_bit ~tree0 ~tree1:(loop tree1)
-        else join thekeyint (leaf thekey value) (prefix :> int) t
-    in loop t
 
   type ('map1,'map2) polysame_domain_for_all2 = { f: 'a 'b. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> bool } [@@unboxed]
   (* Fast equality test between two maps. *)
@@ -711,9 +691,11 @@ module MakeCustomHeterogeneousMap
       | Empty, _ -> tb
       | _, Empty -> ta
       | Leaf{key;value},_ ->
-        idempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
+        insert_for_union ~idempotent:true
+          ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
       | _,Leaf{key;value} ->
-        idempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
+        insert_for_union ~idempotent:true
+          ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
         if ma == mb && pa == pb
@@ -739,9 +721,11 @@ module MakeCustomHeterogeneousMap
     | Empty, _ -> tb
     | _, Empty -> ta
     | Leaf{key;value},_ ->
-      nonidempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
+      insert_for_union ~idempotent:false
+        ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
     | _,Leaf{key;value} ->
-      nonidempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
+      insert_for_union ~idempotent:false
+        ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
     | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
       Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
       if ma == mb && pa == pb

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -521,7 +521,7 @@ module MakeCustomHeterogeneousMap
 
   (* Note: Insert is a bit weird, I am not sure it should be exported. *)
   type 'map polyinsert = { f: 'a . key:'a Key.t -> old:('a,'map) Value.t -> value:('a,'map) Value.t -> ('a,'map) Value.t } [@@unboxed]
-  let insert_for_union: type a map. map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
+  let idempotent_insert_for_union: type a map. map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
     fun f thekey value t ->
     let thekeyint = Key.to_int thekey in
     (* Preserve physical equality whenever possible. *)
@@ -548,6 +548,28 @@ module MakeCustomHeterogeneousMap
           else join thekeyint (leaf thekey value) (prefix :> int) t
       in loop t
     with Unmodified -> t
+
+  let nonidempotent_insert_for_union: type a map. map polyinsert -> a Key.t -> (a,map) Value.t -> map t -> map t =
+    fun f thekey value t ->
+    let thekeyint = Key.to_int thekey in
+    let rec loop t = match NODE.view t with
+      | Empty -> leaf thekey value
+      | Leaf{key;value=old} ->
+        begin match Key.polyeq key thekey with
+          | Eq ->
+            let newv = f.f ~key ~old ~value in
+            leaf key newv
+          | Diff ->
+            let keyint = (Key.to_int key) in
+            join thekeyint (leaf thekey value) keyint t
+        end
+      | Branch{prefix;branching_bit;tree0;tree1} ->
+        if match_prefix thekeyint prefix branching_bit then
+          if (thekeyint land (branching_bit :> int)) == 0
+          then branch ~prefix ~branching_bit ~tree0:(loop tree0) ~tree1
+          else branch ~prefix ~branching_bit ~tree0 ~tree1:(loop tree1)
+        else join thekeyint (leaf thekey value) (prefix :> int) t
+    in loop t
 
   type ('map1,'map2) polysame_domain_for_all2 = { f: 'a 'b. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> bool } [@@unboxed]
   (* Fast equality test between two maps. *)
@@ -688,8 +710,10 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta,NODE.view tb with
       | Empty, _ -> tb
       | _, Empty -> ta
-      | Leaf{key;value},_ -> insert_for_union ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
-      | _,Leaf{key;value} -> insert_for_union ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
+      | Leaf{key;value},_ ->
+        idempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
+      | _,Leaf{key;value} ->
+        idempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
         if ma == mb && pa == pb
@@ -709,6 +733,32 @@ module MakeCustomHeterogeneousMap
           then branch ~prefix:pb ~branching_bit:mb ~tree0:(idempotent_union f ta tb0) ~tree1:tb1
           else branch ~prefix:pb ~branching_bit:mb ~tree0:tb0 ~tree1:(idempotent_union f ta tb1)
         else join (pa :> int) ta (pb :> int) tb
+
+  let rec nonidempotent_union f ta tb =
+    match NODE.view ta,NODE.view tb with
+    | Empty, _ -> tb
+    | _, Empty -> ta
+    | Leaf{key;value},_ ->
+      nonidempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key value old}) key value tb
+    | _,Leaf{key;value} ->
+      nonidempotent_insert_for_union ({f=fun ~key ~old ~value -> f.f key old value}) key value ta
+    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+      if ma == mb && pa == pb
+      (* Same prefix: merge the subtrees *)
+      then
+        let tree0 = nonidempotent_union f ta0 tb0 in
+        let tree1 = nonidempotent_union f ta1 tb1 in
+        branch ~prefix:pa ~branching_bit:ma ~tree0 ~tree1
+      else if branches_before pa ma pb mb
+      then if (ma :> int) land (pb :> int) == 0
+        then branch ~prefix:pa ~branching_bit:ma ~tree0:(nonidempotent_union f ta0 tb) ~tree1:ta1
+        else branch ~prefix:pa ~branching_bit:ma ~tree0:ta0 ~tree1:(nonidempotent_union f ta1 tb)
+      else if branches_before pb mb pa ma
+      then if (mb :> int) land (pa :> int) == 0
+        then branch ~prefix:pb ~branching_bit:mb ~tree0:(nonidempotent_union f ta tb0) ~tree1:tb1
+        else branch ~prefix:pb ~branching_bit:mb ~tree0:tb0 ~tree1:(nonidempotent_union f ta tb1)
+      else join (pa :> int) ta (pb :> int) tb
 
   type ('map1,'map2,'map3) polyinter = { f: 'a. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> ('a,'map3) Value.t } [@@unboxed]
   let rec idempotent_inter f ta tb =
@@ -1226,6 +1276,8 @@ module MakeCustomMap
     BaseMap.filter_map_no_share {f=fun k (Snd v) -> snd_opt (f k v) } a
   let idempotent_union (f: key -> 'a value -> 'a value -> 'a value) a b =
     BaseMap.idempotent_union {f=fun k (Snd v1) (Snd v2) -> Snd (f k v1 v2)} a b
+  let nonidempotent_union (f: key -> 'a value -> 'a value -> 'a value) a b =
+    BaseMap.nonidempotent_union {f=fun k (Snd v1) (Snd v2) -> Snd (f k v1 v2)} a b
   let idempotent_inter (f: key -> 'a value -> 'a value -> 'a value) a b =
     BaseMap.idempotent_inter {f=fun k (Snd v1) (Snd v2) -> Snd (f k v1 v2)} a b
   let nonidempotent_inter_no_share (f: key -> 'a value -> 'b value -> 'c value) a b =

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -490,6 +490,16 @@ module type BASE_MAP = sig
       Complexity is O(log(n)*Delta) where Delta is the number of
       different keys between [map1] and [map2]. *)
 
+  val nonidempotent_union : ('a, 'a, 'a) polyunion -> 'a t -> 'a t -> 'a t
+  (** [nonidempotent_union f map1 map2] returns a map whose keys is the
+      union of the keys of [map1] and [map2]. [f.f] is used to combine
+      the values of keys mapped in both maps.
+      [f.f] is called in increasing {{!unsigned_lt}unsigned order} of
+      {!KEY.to_int}.
+
+      Unlike [idempotent_union], [f.f] is not required to be idempotent. [f.f]
+      is called on two values that are physically equal. *)
+
   type ('map1, 'map2, 'map3) polyinter = {
     f : 'a. 'a key -> ('a, 'map1) value -> ('a, 'map2) value -> ('a, 'map3) value;
   } [@@unboxed]
@@ -1338,6 +1348,16 @@ module type MAP_WITH_VALUE = sig
       different keys between [map1] and [map2].
       [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       [f] is never called on physically equal values. *)
+
+  val nonidempotent_union : (key -> 'a value -> 'a value -> 'a value) -> 'a t -> 'a t -> 'a t
+  (** [nonidempotent_union f map1 map2] returns a map whose keys is the
+      union of the keys of [map1] and [map2]. [f] is used to combine the values
+      of keys mapped in both maps.
+      [f] is called in increasing {{!unsigned_lt}unsigned order} of
+      {!KEY.to_int}.
+
+      Unlike [idempotent_union], [f] is not required to be idempotent. [f] is
+      called on two values that are physically equal. *)
 
   val idempotent_inter : (key -> 'a value -> 'a value -> 'a value) -> 'a t -> 'a t -> 'a t
   (** [idempotent_inter f map1 map2] returns a map whose keys is the

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -90,7 +90,7 @@ let filter_map f = List.filter_map (secondi_opt f)
 let for_all p = List.for_all (uncurry p)
 let exists p = List.exists (uncurry p)
 
-let idempotent_union f m0 m1 =
+let nonidempotent_union f m0 m1 =
   let k0 = keys m0 and k1 = keys m1 in
   let keys = List.sort_uniq compare_keys @@ List.append k0 k1 in
   let aux i =
@@ -102,6 +102,8 @@ let idempotent_union f m0 m1 =
       | None, None -> assert false )
   in
   List.map aux keys
+
+let idempotent_union = nonidempotent_union
 
 let idempotent_inter_filter f m0 m1 =
   let aux (i, x) =

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -121,6 +121,14 @@ let make_setop_test name fun_arb fun_apply intmap_op model_op =
 let idempotent_fst_or_snd =
   oneofl ~print:fst [ ("fst", fun _ a _ -> a); ("snd", fun _ _ b -> b) ]
 
+let nonidempotent_union_f =
+  oneofl ~print:fst
+    [
+      ("fst", fun _ a _ -> a);
+      ("snd", fun _ _ b -> b);
+      ("const", fun _ _ _ -> 'a');
+    ]
+
 (* Like [idempotent_fst_or_snd] but with an extra [None] case. *)
 let idempotent_fst_or_snd_option =
   oneofl ~print:fst
@@ -288,6 +296,8 @@ let tests =
     make_quantifier_test "for_all" Intmap.for_all Model.for_all;
     make_setop_test "idempotent_union" idempotent_fst_or_snd snd
       Intmap.idempotent_union Model.idempotent_union;
+    make_setop_test "nonidempotent_union" nonidempotent_union_f snd
+      Intmap.nonidempotent_union Model.nonidempotent_union;
     make_setop_test "idempotent_inter" idempotent_fst_or_snd snd
       Intmap.idempotent_inter Model.idempotent_inter;
     make_setop_test "idempotent_inter_filter" idempotent_fst_or_snd_option snd


### PR DESCRIPTION
Currently, the `union` operation with a non-idempotent reconciliation function is `slow_merge`.

This adds `nonidempotent_union` which has the following advantages over `slow_merge`:

- The interface is easier to use and look more similar to the union operation that we can see in other datastructures.

- The implementation is faster as it doesn't traverse uncommon subtrees. Also, the reconciliation function is called once for each common binding compared to once per bindings in both maps.

The implementation is basically the same as `idempotent_union` with physical equality checks removed.