### PR TITLE
Dlesbre/more functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.13.0 - UNRELEASED
+
+- Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
+- Add `nonreflexive_subset_domain_for_all2`, `fold2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Type changes: `polyfold2` is renamed to `polyfold2_inter`; `polyfold2_union` is renamed to `polyfold2`
+  and gains a new parameter to allow use with maps of different types. This should not break code that
+  instantiate these types but will break code that has explicit type annotations.
+- Optimize `difference`: it can now skip physically equal subtrees.
+
 # v0.12.0 - 2026-01-19
 
 - Specify that hash-consed and weak nodes are not thread safe (issue [#17](https://github.com/codex-semantics-library/patricia-tree/issues/17))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# v0.13.0 - UNRELEASED
+# v0.13.0 - 2026-04-09
 
-- Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
-- Add `nonidemptotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
+- Add `nonidempotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
+- Add `nonidempotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
 - Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold_on_union`, `fold_on_inter` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
 - Use a more generic type for `fold_on_nonequal_{union,inter}`: both maps are no longer required to
   have the same type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
 - Add `nonidemptotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
-- Add `nonreflexive_subset_domain_for_all2`, `fold2`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold2`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Use a more generic type for `fold_on_nonequal_{union,inter}`: both maps are no longer required to
+  have the same type.
 - Type changes: `polyfold2` is renamed to `polyfold2_inter`; `polyfold2_union` is renamed to `polyfold2`
   and gains a new parameter to allow use with maps of different types. This should not break code that
   instantiate these types but will break code that has explicit type annotations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # v0.13.0 - UNRELEASED
 
 - Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
-- Add `nonreflexive_subset_domain_for_all2`, `fold2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Add `nonidemptotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
+- Add `nonreflexive_subset_domain_for_all2`, `fold2`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
 - Type changes: `polyfold2` is renamed to `polyfold2_inter`; `polyfold2_union` is renamed to `polyfold2`
   and gains a new parameter to allow use with maps of different types. This should not break code that
   instantiate these types but will break code that has explicit type annotations.
 - Optimize `difference`: it can now skip physically equal subtrees.
+- Merge types `polyiter` and `polyfold` into a single type with a parameter for return value.
+  Same for `polyiter2` and `polyfold2`.
 
 # v0.12.0 - 2026-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
 - Add `nonidemptotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
-- Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold2`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold_on_union`, `fold_on_inter`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
 - Use a more generic type for `fold_on_nonequal_{union,inter}`: both maps are no longer required to
   have the same type.
 - Type changes: `polyfold2` is renamed to `polyfold2_inter`; `polyfold2_union` is renamed to `polyfold2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `nonidemptotent_union` (by [julow](https://github.com/Julow) in [#26](https://github.com/codex-semantics-library/patricia-tree/pull/26))
 - Add `nonidemptotent_inter_filter_no_share` (by [julow](https://github.com/Julow) in [#28](https://github.com/codex-semantics-library/patricia-tree/pull/28))
-- Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold_on_union`, `fold_on_inter`, `iter2` and `for_all2` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
+- Add `reflexive_subset_domain_for_all2`, `[non]reflexive_any_domain_for_all2`, `fold_on_union`, `fold_on_inter` ([#27](https://github.com/codex-semantics-library/patricia-tree/pull/27))
 - Use a more generic type for `fold_on_nonequal_{union,inter}`: both maps are no longer required to
   have the same type.
 - Type changes: `polyfold2` is renamed to `polyfold2_inter`; `polyfold2_union` is renamed to `polyfold2`

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -358,6 +358,7 @@ module MakeCustomHeterogeneousMap
     type ('map1, 'map2) polydifference = ('map1,'map2,'map1) polyupdate_multiple_inter
     let rec difference f ta tb =
       match NODE.view ta, Map2.view tb with
+      | _ when phys_same ta tb -> empty
       | Empty, _
       | _, Empty -> ta
       | Leaf{key;value=va},_ -> (try let vb = Map2.find key tb in

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1297,11 +1297,25 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb acc in
     BaseMap.fold_on_nonequal_union {f} ma mb acc
+  let fold2
+      (f: key -> 'a value option -> 'b value option -> 'acc -> 'acc) ma mb acc =
+    let f k va vb acc =
+      let va = Option.map (fun (Snd v) -> v) va in
+      let vb = Option.map (fun (Snd v) -> v) vb in
+      f k va vb acc in
+    BaseMap.fold2 {f} ma mb acc
 
   let pretty ?pp_sep (f: Format.formatter -> key -> 'a value -> unit) fmt m =
     BaseMap.pretty ?pp_sep {f=fun fmt k (Snd v) -> f fmt k v} fmt m
 
   let for_all (f : key -> 'a value -> bool) m = BaseMap.for_all {f = fun k (Snd v) -> f k v} m
+  let for_all2
+      (f: key -> 'a value option -> 'b value option -> bool) ma mb =
+    let f k va vb =
+      let va = Option.map (fun (Snd v) -> v) va in
+      let vb = Option.map (fun (Snd v) -> v) vb in
+      f k va vb in
+    BaseMap.for_all2 {f} ma mb
 
   module WithForeign(Map2 : NODE_WITH_FIND with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -620,6 +620,42 @@ module MakeCustomHeterogeneousMap
         (* Any other case: there are elements in ta that are unmatched in tb. *)
       else false
 
+  let rec nonreflexive_subset_domain_for_all2 f ta tb = match (NODE.view ta),(NODE.view tb) with
+    | Empty, _ -> true
+    | _, Empty -> false
+    | Branch _, Leaf _ -> false
+    | Leaf {key=keya;value=valuea}, viewb ->
+      (* Reimplement find locally, mostly because of typing issues
+         (which could be solved if we had a version of find that
+         returns a (key,value) pair. *)
+      let searched = Key.to_int keya in
+      let rec search = function
+        | Leaf{key=keyb;value=valueb} ->
+          begin match Key.polyeq keya keyb with
+            | Diff -> false
+            | Eq -> f.f keya valuea valueb
+          end
+        | Branch{branching_bit;tree0;tree1;_} ->
+          if ((branching_bit :> int) land searched == 0)
+          then search (NODE.view tree0)
+          else search (NODE.view tree1)
+        | Empty -> false (* Can only happen on weak nodes. *)
+      in search viewb
+    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+      if ma == mb && pa == pb
+      (* Same prefix: divide the search. *)
+      then
+        (nonreflexive_subset_domain_for_all2 f ta0 tb0) &&
+        (nonreflexive_subset_domain_for_all2 f ta1 tb1)
+        (* Case where ta have to be included in one of tb0 or tb1. *)
+      else if branches_before pb mb pa ma
+      then if (mb :> int) land (pa :> int) == 0
+        then nonreflexive_subset_domain_for_all2 f ta tb0
+        else nonreflexive_subset_domain_for_all2 f ta tb1
+        (* Any other case: there are elements in ta that are unmatched in tb. *)
+      else false
+
   type 'map polycompare =
       { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]
 
@@ -1274,6 +1310,8 @@ module MakeCustomMap
     BaseMap.nonreflexive_same_domain_for_all2 {f=fun k (Snd v1) (Snd v2) -> f k v1 v2} a b
   let reflexive_subset_domain_for_all2 (f: key -> 'a value -> 'a value -> bool) a b =
     BaseMap.reflexive_subset_domain_for_all2 {f=fun k (Snd v1) (Snd v2) -> f k v1 v2} a b
+  let nonreflexive_subset_domain_for_all2 (f: key -> 'a value -> 'a value -> bool) a b =
+    BaseMap.nonreflexive_subset_domain_for_all2 {f=fun k (Snd v1) (Snd v2) -> f k v1 v2} a b
   let slow_merge (f : key -> 'a value option -> 'b value option -> 'c value option) a b = BaseMap.slow_merge {f=fun k v1 v2 -> snd_opt (f k (opt_snd v1) (opt_snd v2))} a b
   let symmetric_difference (f: key -> 'a value -> 'a value -> 'a value option) a b = BaseMap.symmetric_difference {f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2)} a b
   let difference (f: key -> 'a value -> 'b value -> 'a value option) a b = BaseMap.difference { f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2) } a b

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1068,8 +1068,6 @@ module MakeCustomHeterogeneousMap
   let fold_on_nonequal_union f m1 m2 = fold_union ~reflexive:true f m1 m2
   let fold_on_union f m1 m2 = fold_union ~reflexive:false f m1 m2
 
-  let iter2 f m1 m2 = fold_on_union { f=fun k v1 v2 () -> f.f k v1 v2 } m1 m2 ()
-
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
   let rec for_all f m = match NODE.view m with
@@ -1286,8 +1284,6 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb acc in
     BaseMap.fold_on_union {f} ma mb acc
-
-  let iter2 f ma mb = fold_on_union (fun k va vb () -> f k va vb) ma mb ()
 
   let pretty ?pp_sep (f: Format.formatter -> key -> 'a value -> unit) fmt m =
     BaseMap.pretty ?pp_sep {f=fun fmt k (Snd v) -> f fmt k v} fmt m

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -37,6 +37,7 @@ let match_prefix k p m = mask k m = p
 let [@inline always] branches_before l_prefix (l_mask : mask) (r_prefix : intkey) (r_mask : mask) =
   unsigned_lt (r_mask :> int) (l_mask :> int) && match_prefix (r_prefix :> int) l_prefix l_mask
 
+exception False
 
 module MakeCustomHeterogeneousMap
     (Key:HETEROGENEOUS_KEY)
@@ -953,7 +954,7 @@ module MakeCustomHeterogeneousMap
       fold f tree1 acc
 
 
-  type ('acc,'map) polyfold2 = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
+  type ('acc,'map) polyfold2_inter = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
   let rec fold_on_nonequal_inter f ta tb acc =
     if ta == tb then acc
     else match NODE.view ta,NODE.view tb with
@@ -987,11 +988,31 @@ module MakeCustomHeterogeneousMap
         else acc
 
 
-  type ('acc,'map) polyfold2_union =
-    { f: 'a. 'a key -> ('a,'map) value option -> ('a,'map) value option ->
+  type ('acc,'map1,'map2) polyfold2=
+    { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option ->
         'acc -> 'acc } [@@unboxed]
+
+  (** Intermediate function for folding on union, when folding on a leaf and a branch:
+      Call fall on the branch and insert the correct call to leaf as needed. *)
+  let fold_with_missing_key (type k v1 v2 a) ~reflexive (f: (a,v1,v2) polyfold2) (key: k Key.t) value m acc =
+    let id_a = Key.to_int key in
+    let fold_func (type k') (keyb: k' Key.t) valueb (acc, found_key) =
+      if found_key then f.f keyb None (Some valueb) acc, found_key else
+      let id_b = Key.to_int keyb in
+      if unsigned_lt id_b id_a then f.f keyb None (Some valueb) acc, found_key
+      else if unsigned_lt id_a id_b then
+        f.f key (Some value) None acc |> f.f keyb None (Some valueb), true
+      else match Key.polyeq key keyb with
+      | Eq ->
+        if reflexive && phys_same value valueb then (acc,true)
+        else (f.f key (Some value) (Some valueb) acc,true)
+      | Diff ->
+        raise (Invalid_argument "Keys with same to_int value are not equal by polyeq")
+      in let (acc, found) = fold {f=fun k v a -> fold_func k v a} m (acc, false) in
+      if found then acc else f.f key (Some value) None acc
+
   let rec fold_on_nonequal_union:
-    'm 'acc. ('acc,'m) polyfold2_union -> 'm t -> 'm t -> 'acc -> 'acc =
+    'm 'acc. ('acc,'m,'m) polyfold2 -> 'm t -> 'm t -> 'acc -> 'acc =
     fun (type m) f (ta:m t) (tb:m t) acc ->
     if ta == tb then acc
     else
@@ -1002,52 +1023,8 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta,NODE.view tb with
       | Empty, _ -> fold fright tb acc
       | _, Empty -> fold fleft ta acc
-      | Leaf{key;value},_ ->
-        let ida = Key.to_int key in
-        (* Fold on the rest, knowing that ida may or may not be in b. So we fold and use
-           did_a to remember if we already did the call to a. *)
-        let g (type b) (keyb:b key) (valueb:(b,m) value) (acc,did_a) =
-          let default() = (f.f keyb None (Some valueb) acc,did_a) in
-          if did_a then default()
-          else
-            let idb = Key.to_int keyb in
-            if unsigned_lt idb ida then default()
-            else if unsigned_lt ida idb then
-              let acc = f.f key (Some value) None acc in
-              let acc = f.f keyb None (Some valueb) acc in
-              (acc,true)
-            else match Key.polyeq key keyb with
-              | Eq ->
-                if value == valueb then (acc,true)
-                else (f.f key (Some value) (Some valueb) acc,true)
-              | Diff ->
-                raise (Invalid_argument "Keys with same to_int value are not equal by polyeq")
-        in
-        let (acc,found) = fold{f=fun keyb valueb acc -> g keyb valueb acc} tb (acc,false) in
-        if found then acc
-        else f.f key (Some value) None acc
-      | _,Leaf{key;value} ->
-        let idb = Key.to_int key in
-        let g (type a) (keya: a key) (valuea:(a,m) value) (acc,did_b) =
-          let default() = (f.f keya (Some valuea) None acc,did_b) in
-          if did_b then default()
-          else
-            let ida = Key.to_int keya in
-            if unsigned_lt ida idb then default()
-            else if unsigned_lt idb ida then
-              let acc = f.f key None (Some value) acc in
-              let acc = f.f keya (Some valuea) None acc in
-              (acc,true)
-            else match Key.polyeq keya key with
-              | Eq ->
-                if valuea == value then (acc,true)
-                else (f.f keya (Some valuea) (Some value) acc,true)
-              | Diff ->
-                raise (Invalid_argument "Keys with same to_int value are not equal by polyeq")
-        in
-        let (acc,found) = fold{f=fun keya valuea acc -> g keya valuea acc} ta (acc,false) in
-        if found then acc
-        else f.f key None (Some value) acc
+      | Leaf{key;value},_ -> fold_with_missing_key ~reflexive:true f key value tb acc
+      | _,Leaf{key;value} -> fold_with_missing_key ~reflexive:true {f=fun k v1 v2->f.f k v2 v1} key value ta acc
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
         if ma == mb && pa == pb
@@ -1087,12 +1064,47 @@ module MakeCustomHeterogeneousMap
           let acc = fold fleft ta acc in
           acc
 
+  let rec fold2: type
+    m1 m2 acc. (acc,m1,m2) polyfold2 -> m1 t -> m2 t -> acc -> acc =
+    fun f ta tb acc ->
+      let fleft:(_,_) polyfold = {f=fun key value acc -> f.f key (Some value) None acc} in
+      let fright:(_,_)polyfold = {f=fun key value acc -> f.f key None (Some value) acc} in
+      match NODE.view ta,NODE.view tb with
+      | Empty, _ -> fold fright tb acc
+      | _, Empty -> fold fleft ta acc
+      | Leaf{key;value},_ -> fold_with_missing_key ~reflexive:false f key value tb acc
+      | _,Leaf{key;value} -> fold_with_missing_key ~reflexive:false {f=fun k v1 v2->f.f k v2 v1} key value ta acc
+      | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+        Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+        if ma == mb && pa == pb
+        (* Same prefix: merge the subtrees *)
+        then acc |> fold2 f ta0 tb0 |> fold2 f ta1 tb1
+        else if branches_before pa ma pb mb
+        then if (ma :> int) land (pb :> int) == 0
+          then acc |> fold2 f ta0 tb |> fold fleft ta1
+          else acc |> fold fleft ta0 |> fold2 f ta1 tb
+        else if branches_before pb mb pa ma
+        then if (mb :> int) land (pa :> int) == 0
+          then acc |> fold2 f ta tb0 |> fold fright tb1
+          else acc |> fold fright tb0 |> fold2 f ta tb1
+        else
+        (* Distinct subtrees: process them in increasing order of keys. *)
+        if unsigned_lt (pa :> int) (pb :> int)
+        then acc |> fold fleft ta |> fold fright tb
+        else acc |> fold fright tb |> fold fleft ta
+
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
   let rec for_all f m = match NODE.view m with
     | Empty -> true
     | Leaf{key;value} -> f.f key value
     | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
+
+  type ('map1,'map2) polyfor_all2 =
+    { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
+  let for_all2 f ta tb =
+    try fold2 {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
+    with False -> false
 
   let rec to_seq m () = match NODE.view m with
     | Empty -> Seq.Nil

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -955,19 +955,19 @@ module MakeCustomHeterogeneousMap
       fold f tree1 acc
 
 
-  type ('acc,'map) polyfold2_inter = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
+  type ('acc,'map1,'map2) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc -> 'acc } [@@unboxed]
   let rec fold_on_nonequal_inter f ta tb acc =
-    if ta == tb then acc
+    if phys_same ta tb then acc
     else match NODE.view ta,NODE.view tb with
       | Empty, _ | _, Empty -> acc
       | Leaf{key;value},_ ->
         (try let valueb = find key tb in
-           if valueb == value then acc else
+           if phys_same valueb value then acc else
              f.f key value valueb acc
          with Not_found -> acc)
       | _,Leaf{key;value} ->
         (try let valuea = find key ta in
-           if valuea == value then acc else
+           if phys_same valuea value then acc else
              f.f key valuea value acc
          with Not_found -> acc)
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
@@ -1011,9 +1011,9 @@ module MakeCustomHeterogeneousMap
       in let (acc, found) = fold {f=fun k v a -> fold_func k v a} m (acc, false) in
       if found then acc else f.f key (Some value) None acc
 
-  let rec fold_on_nonequal_union: type m acc. (m,m,acc->acc) polyfold2 -> m t -> m t -> acc -> acc =
+  let rec fold_on_nonequal_union: type m1 m2 acc. (m1,m2,acc->acc) polyfold2 -> m1 t -> m2 t -> acc -> acc =
     fun f ta tb acc ->
-    if ta == tb then acc
+    if phys_same ta tb then acc
     else
       let fleft:(_,_) polyfold =
         {f=fun key value acc -> f.f key (Some value) None acc} in
@@ -1105,6 +1105,9 @@ module MakeCustomHeterogeneousMap
     { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
   let nonreflexive_any_domain_for_all2 f ta tb =
     try fold2 {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
+    with False -> false
+  let reflexive_any_domain_for_all2 f ta tb =
+    try fold_on_nonequal_union {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
     with False -> false
 
   let rec to_seq m () = match NODE.view m with
@@ -1287,11 +1290,11 @@ module MakeCustomMap
   let difference (f: key -> 'a value -> 'b value -> 'a value option) a b = BaseMap.difference { f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2) } a b
   let iter (f: key -> 'a value -> unit) a = BaseMap.iter {f=fun k (Snd v) -> f k v} a
   let fold (f: key -> 'a value -> 'acc -> 'acc) m acc = BaseMap.fold {f=fun k (Snd v) acc -> f k v acc} m acc
-  let fold_on_nonequal_inter (f: key -> 'a value -> 'a value -> 'acc -> 'acc) ma mb acc =
+  let fold_on_nonequal_inter (f: key -> 'a value -> 'b value -> 'acc -> 'acc) ma mb acc =
     let f k (Snd va) (Snd vb) acc = f k va vb acc in
     BaseMap.fold_on_nonequal_inter {f} ma mb acc
   let fold_on_nonequal_union
-      (f: key -> 'a value option -> 'a value option -> 'acc -> 'acc) ma mb acc =
+      (f: key -> 'a value option -> 'b value option -> 'acc -> 'acc) ma mb acc =
     let f k va vb acc =
       let va = Option.map (fun (Snd v) -> v) va in
       let vb = Option.map (fun (Snd v) -> v) vb in
@@ -1317,6 +1320,13 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb in
     BaseMap.nonreflexive_any_domain_for_all2 {f} ma mb
+  let reflexive_any_domain_for_all2
+      (f: key -> 'a value option -> 'b value option -> bool) ma mb =
+    let f k va vb =
+      let va = Option.map (fun (Snd v) -> v) va in
+      let vb = Option.map (fun (Snd v) -> v) vb in
+      f k va vb in
+    BaseMap.reflexive_any_domain_for_all2 {f} ma mb
 
   module WithForeign(Map2 : NODE_WITH_FIND with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -956,18 +956,18 @@ module MakeCustomHeterogeneousMap
 
 
   type ('acc,'map1,'map2) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc -> 'acc } [@@unboxed]
-  let rec fold_on_nonequal_inter f ta tb acc =
-    if phys_same ta tb then acc
+  let rec fold_inter ~reflexive f ta tb acc =
+    if reflexive && phys_same ta tb then acc
     else match NODE.view ta,NODE.view tb with
       | Empty, _ | _, Empty -> acc
       | Leaf{key;value},_ ->
         (try let valueb = find key tb in
-           if phys_same valueb value then acc else
+           if reflexive && phys_same valueb value then acc else
              f.f key value valueb acc
          with Not_found -> acc)
       | _,Leaf{key;value} ->
         (try let valuea = find key ta in
-           if phys_same valuea value then acc else
+           if reflexive && phys_same valuea value then acc else
              f.f key valuea value acc
          with Not_found -> acc)
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
@@ -975,19 +975,21 @@ module MakeCustomHeterogeneousMap
         if ma == mb && pa == pb
         (* Same prefix: fold on each subtrees *)
         then
-          let acc = fold_on_nonequal_inter f ta0 tb0 acc in
-          let acc = fold_on_nonequal_inter f ta1 tb1 acc in
+          let acc = fold_inter ~reflexive f ta0 tb0 acc in
+          let acc = fold_inter ~reflexive f ta1 tb1 acc in
           acc
         else if branches_before pa ma pb mb
         then if (ma :> int) land (pb :> int) == 0
-          then fold_on_nonequal_inter f ta0 tb acc
-          else fold_on_nonequal_inter f ta1 tb acc
+          then fold_inter ~reflexive f ta0 tb acc
+          else fold_inter ~reflexive f ta1 tb acc
         else if branches_before pb mb pa ma
         then if (mb :> int) land (pa :> int) == 0
-          then fold_on_nonequal_inter f ta tb0 acc
-          else fold_on_nonequal_inter f ta tb1 acc
+          then fold_inter ~reflexive f ta tb0 acc
+          else fold_inter ~reflexive f ta tb1 acc
         else acc
 
+  let fold_on_nonequal_inter f m1 m2 = fold_inter ~reflexive:true f m1 m2
+  let fold_on_inter f m1 m2 = fold_inter ~reflexive:false f m1 m2
 
   type ('map1,'map2,'res) polyfold2 =
     { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
@@ -1011,9 +1013,9 @@ module MakeCustomHeterogeneousMap
       in let (acc, found) = fold {f=fun k v a -> fold_func k v a} m (acc, false) in
       if found then acc else f.f key (Some value) None acc
 
-  let rec fold_on_nonequal_union: type m1 m2 acc. (m1,m2,acc->acc) polyfold2 -> m1 t -> m2 t -> acc -> acc =
-    fun f ta tb acc ->
-    if phys_same ta tb then acc
+  let rec fold_union: type m1 m2 acc. reflexive:bool -> (m1,m2,acc->acc) polyfold2 -> m1 t -> m2 t -> acc -> acc =
+    fun ~reflexive f ta tb acc ->
+    if reflexive && phys_same ta tb then acc
     else
       let fleft:(_,_) polyfold =
         {f=fun key value acc -> f.f key (Some value) None acc} in
@@ -1022,35 +1024,35 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta,NODE.view tb with
       | Empty, _ -> fold fright tb acc
       | _, Empty -> fold fleft ta acc
-      | Leaf{key;value},_ -> fold_with_missing_key ~reflexive:true f key value tb acc
-      | _,Leaf{key;value} -> fold_with_missing_key ~reflexive:true {f=fun k v1 v2->f.f k v2 v1} key value ta acc
+      | Leaf{key;value},_ -> fold_with_missing_key ~reflexive f key value tb acc
+      | _,Leaf{key;value} -> fold_with_missing_key ~reflexive {f=fun k v1 v2->f.f k v2 v1} key value ta acc
       | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
         Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
         if ma == mb && pa == pb
         (* Same prefix: merge the subtrees *)
         then
-          let acc = fold_on_nonequal_union f ta0 tb0 acc in
-          let acc = fold_on_nonequal_union f ta1 tb1 acc in
+          let acc = fold_union ~reflexive f ta0 tb0 acc in
+          let acc = fold_union ~reflexive f ta1 tb1 acc in
           acc
         else if branches_before pa ma pb mb
         then if (ma :> int) land (pb :> int) == 0
           then
-            let acc = fold_on_nonequal_union f ta0 tb acc in
+            let acc = fold_union ~reflexive f ta0 tb acc in
             let acc = fold fleft ta1 acc in
             acc
           else
             let acc = fold fleft ta0 acc in
-            let acc = fold_on_nonequal_union f ta1 tb acc in
+            let acc = fold_union ~reflexive f ta1 tb acc in
             acc
         else if branches_before pb mb pa ma
         then if (mb :> int) land (pa :> int) == 0
           then
-            let acc = fold_on_nonequal_union f ta tb0 acc in
+            let acc = fold_union ~reflexive f ta tb0 acc in
             let acc = fold fright tb1 acc in
             acc
           else
             let acc = fold fright tb0 acc in
-            let acc = fold_on_nonequal_union f ta tb1 acc in
+            let acc = fold_union ~reflexive f ta tb1 acc in
             acc
         else
         (* Distinct subtrees: process them in increasing order of keys. *)
@@ -1063,36 +1065,10 @@ module MakeCustomHeterogeneousMap
           let acc = fold fleft ta acc in
           acc
 
-  let rec fold2: type
-    m1 m2 acc. (m1,m2,acc->acc) polyfold2 -> m1 t -> m2 t -> acc -> acc =
-    fun f ta tb acc ->
-      let fleft:(_,_) polyfold = {f=fun key value acc -> f.f key (Some value) None acc} in
-      let fright:(_,_)polyfold = {f=fun key value acc -> f.f key None (Some value) acc} in
-      match NODE.view ta,NODE.view tb with
-      | Empty, _ -> fold fright tb acc
-      | _, Empty -> fold fleft ta acc
-      | Leaf{key;value},_ -> fold_with_missing_key ~reflexive:false f key value tb acc
-      | _,Leaf{key;value} -> fold_with_missing_key ~reflexive:false {f=fun k v1 v2->f.f k v2 v1} key value ta acc
-      | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
-        Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
-        if ma == mb && pa == pb
-        (* Same prefix: merge the subtrees *)
-        then acc |> fold2 f ta0 tb0 |> fold2 f ta1 tb1
-        else if branches_before pa ma pb mb
-        then if (ma :> int) land (pb :> int) == 0
-          then acc |> fold2 f ta0 tb |> fold fleft ta1
-          else acc |> fold fleft ta0 |> fold2 f ta1 tb
-        else if branches_before pb mb pa ma
-        then if (mb :> int) land (pa :> int) == 0
-          then acc |> fold2 f ta tb0 |> fold fright tb1
-          else acc |> fold fright tb0 |> fold2 f ta tb1
-        else
-        (* Distinct subtrees: process them in increasing order of keys. *)
-        if unsigned_lt (pa :> int) (pb :> int)
-        then acc |> fold fleft ta |> fold fright tb
-        else acc |> fold fright tb |> fold fleft ta
+  let fold_on_nonequal_union f m1 m2 = fold_union ~reflexive:true f m1 m2
+  let fold_on_union f m1 m2 = fold_union ~reflexive:false f m1 m2
 
-  let iter2 f m1 m2 = fold2 { f=fun k v1 v2 () -> f.f k v1 v2 } m1 m2 ()
+  let iter2 f m1 m2 = fold_on_union { f=fun k v1 v2 () -> f.f k v1 v2 } m1 m2 ()
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
@@ -1104,7 +1080,7 @@ module MakeCustomHeterogeneousMap
   type ('map1,'map2) polyfor_all2 =
     { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
   let nonreflexive_any_domain_for_all2 f ta tb =
-    try fold2 {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
+    try fold_on_union {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
     with False -> false
   let reflexive_any_domain_for_all2 f ta tb =
     try fold_on_nonequal_union {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
@@ -1293,6 +1269,9 @@ module MakeCustomMap
   let fold_on_nonequal_inter (f: key -> 'a value -> 'b value -> 'acc -> 'acc) ma mb acc =
     let f k (Snd va) (Snd vb) acc = f k va vb acc in
     BaseMap.fold_on_nonequal_inter {f} ma mb acc
+  let fold_on_inter (f: key -> 'a value -> 'b value -> 'acc -> 'acc) ma mb acc =
+    let f k (Snd va) (Snd vb) acc = f k va vb acc in
+    BaseMap.fold_on_inter {f} ma mb acc
   let fold_on_nonequal_union
       (f: key -> 'a value option -> 'b value option -> 'acc -> 'acc) ma mb acc =
     let f k va vb acc =
@@ -1300,14 +1279,15 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb acc in
     BaseMap.fold_on_nonequal_union {f} ma mb acc
-  let fold2
+  let fold_on_union
       (f: key -> 'a value option -> 'b value option -> 'acc -> 'acc) ma mb acc =
     let f k va vb acc =
       let va = Option.map (fun (Snd v) -> v) va in
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb acc in
-    BaseMap.fold2 {f} ma mb acc
-  let iter2 f ma mb = fold2 (fun k va vb () -> f k va vb) ma mb ()
+    BaseMap.fold_on_union {f} ma mb acc
+
+  let iter2 f ma mb = fold_on_union (fun k va vb () -> f k va vb) ma mb ()
 
   let pretty ?pp_sep (f: Format.formatter -> key -> 'a value -> unit) fmt m =
     BaseMap.pretty ?pp_sep {f=fun fmt k (Snd v) -> f fmt k v} fmt m

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -941,13 +941,12 @@ module MakeCustomHeterogeneousMap
           else branch ~prefix:pb ~branching_bit:mb ~tree0:tb0 ~tree1:(symmetric_difference f ta tb1)
         else join (pa :> int) ta (pb :> int) tb
 
-  type 'map polyiter = { f: 'a. 'a Key.t -> ('a,'map) Value.t -> unit } [@@unboxed]
+  type ('map,'res) polyfold = { f: 'a. 'a key -> ('a,'map) value -> 'res } [@@unboxed]
   let rec iter f x = match NODE.view x with
     | Empty -> ()
     | Leaf{key;value} -> f.f key value
     | Branch{tree0;tree1;_} -> iter f tree0; iter f tree1
 
-  type ('acc,'map) polyfold = { f: 'a. 'a Key.t -> ('a,'map) Value.t -> 'acc -> 'acc } [@@unboxed]
   let rec fold f m acc = match NODE.view m with
     | Empty -> acc
     | Leaf{key;value} -> f.f key value acc
@@ -990,13 +989,12 @@ module MakeCustomHeterogeneousMap
         else acc
 
 
-  type ('acc,'map1,'map2) polyfold2=
-    { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option ->
-        'acc -> 'acc } [@@unboxed]
+  type ('map1,'map2,'res) polyfold2 =
+    { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
 
   (** Intermediate function for folding on union, when folding on a leaf and a branch:
       Call fall on the branch and insert the correct call to leaf as needed. *)
-  let fold_with_missing_key (type k v1 v2 a) ~reflexive (f: (a,v1,v2) polyfold2) (key: k Key.t) value m acc =
+  let fold_with_missing_key (type k v1 v2 a) ~reflexive (f: (v1,v2,a->a) polyfold2) (key: k Key.t) value m acc =
     let id_a = Key.to_int key in
     let fold_func (type k') (keyb: k' Key.t) valueb (acc, found_key) =
       if found_key then f.f keyb None (Some valueb) acc, found_key else
@@ -1013,9 +1011,8 @@ module MakeCustomHeterogeneousMap
       in let (acc, found) = fold {f=fun k v a -> fold_func k v a} m (acc, false) in
       if found then acc else f.f key (Some value) None acc
 
-  let rec fold_on_nonequal_union:
-    'm 'acc. ('acc,'m,'m) polyfold2 -> 'm t -> 'm t -> 'acc -> 'acc =
-    fun (type m) f (ta:m t) (tb:m t) acc ->
+  let rec fold_on_nonequal_union: type m acc. (m,m,acc->acc) polyfold2 -> m t -> m t -> acc -> acc =
+    fun f ta tb acc ->
     if ta == tb then acc
     else
       let fleft:(_,_) polyfold =
@@ -1067,7 +1064,7 @@ module MakeCustomHeterogeneousMap
           acc
 
   let rec fold2: type
-    m1 m2 acc. (acc,m1,m2) polyfold2 -> m1 t -> m2 t -> acc -> acc =
+    m1 m2 acc. (m1,m2,acc->acc) polyfold2 -> m1 t -> m2 t -> acc -> acc =
     fun f ta tb acc ->
       let fleft:(_,_) polyfold = {f=fun key value acc -> f.f key (Some value) None acc} in
       let fright:(_,_)polyfold = {f=fun key value acc -> f.f key None (Some value) acc} in
@@ -1094,6 +1091,8 @@ module MakeCustomHeterogeneousMap
         if unsigned_lt (pa :> int) (pb :> int)
         then acc |> fold fleft ta |> fold fright tb
         else acc |> fold fright tb |> fold fleft ta
+
+  let iter2 f m1 m2 = fold2 { f=fun k v1 v2 () -> f.f k v1 v2 } m1 m2 ()
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
@@ -1162,11 +1161,10 @@ module MakeCustomHeterogeneousSet
     let f:(unit,unit,unit) BaseMap.polyinter = {f=fun _ () () -> ()} in
     fun [@specialise] sa sb -> (BaseMap.idempotent_inter (* [@specialised] *)) f sa sb
 
-  type polyiter = { f: 'a. 'a elt -> unit; } [@@unboxed]
+  type 'res polyfold = { f: 'a. 'a key -> 'res } [@@unboxed]
   let iter f set = BaseMap.iter {f=fun k () -> f.f k} set
 
   (* TODO: A real implementation of fold would be faster. *)
-  type 'acc polyfold = { f: 'a. 'a key -> 'acc -> 'acc } [@@unboxed]
   let fold f set acc =
     let f: type a. a key -> unit -> 'acc -> 'acc = fun k () acc -> f.f k acc in
     BaseMap.fold { f } set acc

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1161,7 +1161,7 @@ module MakeCustomHeterogeneousSet
     let f:(unit,unit,unit) BaseMap.polyinter = {f=fun _ () () -> ()} in
     fun [@specialise] sa sb -> (BaseMap.idempotent_inter (* [@specialised] *)) f sa sb
 
-  type 'res polyfold = { f: 'a. 'a key -> 'res } [@@unboxed]
+  type 'res polyfold = { f: 'a. 'a elt -> 'res } [@@unboxed]
   let iter f set = BaseMap.iter {f=fun k () -> f.f k} set
 
   (* TODO: A real implementation of fold would be faster. *)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1104,7 +1104,7 @@ module MakeCustomHeterogeneousMap
 
   type ('map1,'map2) polyfor_all2 =
     { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
-  let for_all2 f ta tb =
+  let nonreflexive_any_domain_for_all2 f ta tb =
     try fold2 {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
     with False -> false
 
@@ -1311,13 +1311,13 @@ module MakeCustomMap
     BaseMap.pretty ?pp_sep {f=fun fmt k (Snd v) -> f fmt k v} fmt m
 
   let for_all (f : key -> 'a value -> bool) m = BaseMap.for_all {f = fun k (Snd v) -> f k v} m
-  let for_all2
+  let nonreflexive_any_domain_for_all2
       (f: key -> 'a value option -> 'b value option -> bool) ma mb =
     let f k va vb =
       let va = Option.map (fun (Snd v) -> v) va in
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb in
-    BaseMap.for_all2 {f} ma mb
+    BaseMap.nonreflexive_any_domain_for_all2 {f} ma mb
 
   module WithForeign(Map2 : NODE_WITH_FIND with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -560,6 +560,7 @@ module MakeCustomHeterogeneousMap
   (* Fast equality test between two maps. *)
   let rec same_domain_for_all2 ~reflexive f ta tb = match (NODE.view ta),(NODE.view tb) with
     | _ when reflexive && phys_same ta tb -> true (* Skip same subtrees thanks to reflexivity. *)
+    | Empty, Empty -> true
     | Empty, _ | _, Empty -> false
     | Leaf _, Branch _ | Branch _, Leaf _ -> false
     | Leaf{key=keya;value=valuea}, Leaf{key=keyb;value=valueb} ->

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1304,6 +1304,7 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb acc in
     BaseMap.fold2 {f} ma mb acc
+  let iter2 f ma mb = fold2 (fun k va vb () -> f k va vb) ma mb ()
 
   let pretty ?pp_sep (f: Format.formatter -> key -> 'a value -> unit) fmt m =
     BaseMap.pretty ?pp_sep {f=fun fmt k (Snd v) -> f fmt k v} fmt m

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -26,6 +26,9 @@ open Signatures
 open Key_value
 open Nodes
 
+external phys_same : 'a -> 'b -> bool = "%eq"
+(** Physical equality with permissive types *)
+
 (** [match_prefix k p m] returns [true] if and only if the key [k] has prefix [p] up to bit [m]. *)
 let match_prefix k p m = mask k m = p
 
@@ -553,8 +556,8 @@ module MakeCustomHeterogeneousMap
 
   type ('map1,'map2) polysame_domain_for_all2 = { f: 'a 'b. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> bool } [@@unboxed]
   (* Fast equality test between two maps. *)
-  let rec reflexive_same_domain_for_all2 f ta tb = match (NODE.view ta),(NODE.view tb) with
-    | _ when ta == tb -> true (* Skip same subtrees thanks to reflexivity. *)
+  let rec same_domain_for_all2 ~reflexive f ta tb = match (NODE.view ta),(NODE.view tb) with
+    | _ when reflexive && phys_same ta tb -> true (* Skip same subtrees thanks to reflexivity. *)
     | Empty, _ | _, Empty -> false
     | Leaf _, Branch _ | Branch _, Leaf _ -> false
     | Leaf{key=keya;value=valuea}, Leaf{key=keyb;value=valueb} ->
@@ -565,26 +568,14 @@ module MakeCustomHeterogeneousMap
     | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
       Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
       pa == pb && ma == mb &&
-      reflexive_same_domain_for_all2 f ta0 tb0 &&
-      reflexive_same_domain_for_all2 f ta1 tb1
+      same_domain_for_all2 ~reflexive f ta0 tb0 &&
+      same_domain_for_all2 ~reflexive f ta1 tb1
 
-  let rec nonreflexive_same_domain_for_all2 f ta tb = match (NODE.view ta),(NODE.view tb) with
-    | Empty, Empty -> true
-    | Empty, _ | _, Empty -> false
-    | Leaf _, Branch _ | Branch _, Leaf _ -> false
-    | Leaf{key=keya;value=valuea}, Leaf{key=keyb;value=valueb} ->
-      begin match Key.polyeq keya keyb with
-        | Diff -> false
-        | Eq -> f.f keya valuea valueb
-      end
-    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
-      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
-      pa == pb && ma == mb &&
-      nonreflexive_same_domain_for_all2 f ta0 tb0 &&
-      nonreflexive_same_domain_for_all2 f ta1 tb1
+  let reflexive_same_domain_for_all2 f ta tb = same_domain_for_all2 ~reflexive:true f ta tb
+  let nonreflexive_same_domain_for_all2 f ta tb = same_domain_for_all2 ~reflexive:false f ta tb
 
-  let rec reflexive_subset_domain_for_all2 f ta tb = match (NODE.view ta),(NODE.view tb) with
-    | _ when ta == tb -> true   (* Skip same subtrees thanks to reflexivity. *)
+  let rec subset_domain_for_all2 ~reflexive f ta tb = match (NODE.view ta),(NODE.view tb) with
+    | _ when reflexive && phys_same ta tb -> true   (* Skip same subtrees thanks to reflexivity. *)
     | Empty, _ -> true
     | _, Empty -> false
     | Branch _, Leaf _ -> false
@@ -610,51 +601,18 @@ module MakeCustomHeterogeneousMap
       if ma == mb && pa == pb
       (* Same prefix: divide the search. *)
       then
-        (reflexive_subset_domain_for_all2 f ta0 tb0) &&
-        (reflexive_subset_domain_for_all2 f ta1 tb1)
+        (subset_domain_for_all2 ~reflexive f ta0 tb0) &&
+        (subset_domain_for_all2 ~reflexive f ta1 tb1)
         (* Case where ta have to be included in one of tb0 or tb1. *)
       else if branches_before pb mb pa ma
       then if (mb :> int) land (pa :> int) == 0
-        then reflexive_subset_domain_for_all2 f ta tb0
-        else reflexive_subset_domain_for_all2 f ta tb1
+        then subset_domain_for_all2 ~reflexive f ta tb0
+        else subset_domain_for_all2 ~reflexive f ta tb1
         (* Any other case: there are elements in ta that are unmatched in tb. *)
       else false
 
-  let rec nonreflexive_subset_domain_for_all2 f ta tb = match (NODE.view ta),(NODE.view tb) with
-    | Empty, _ -> true
-    | _, Empty -> false
-    | Branch _, Leaf _ -> false
-    | Leaf {key=keya;value=valuea}, viewb ->
-      (* Reimplement find locally, mostly because of typing issues
-         (which could be solved if we had a version of find that
-         returns a (key,value) pair. *)
-      let searched = Key.to_int keya in
-      let rec search = function
-        | Leaf{key=keyb;value=valueb} ->
-          begin match Key.polyeq keya keyb with
-            | Diff -> false
-            | Eq -> f.f keya valuea valueb
-          end
-        | Branch{branching_bit;tree0;tree1;_} ->
-          if ((branching_bit :> int) land searched == 0)
-          then search (NODE.view tree0)
-          else search (NODE.view tree1)
-        | Empty -> false (* Can only happen on weak nodes. *)
-      in search viewb
-    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
-      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
-      if ma == mb && pa == pb
-      (* Same prefix: divide the search. *)
-      then
-        (nonreflexive_subset_domain_for_all2 f ta0 tb0) &&
-        (nonreflexive_subset_domain_for_all2 f ta1 tb1)
-        (* Case where ta have to be included in one of tb0 or tb1. *)
-      else if branches_before pb mb pa ma
-      then if (mb :> int) land (pa :> int) == 0
-        then nonreflexive_subset_domain_for_all2 f ta tb0
-        else nonreflexive_subset_domain_for_all2 f ta tb1
-        (* Any other case: there are elements in ta that are unmatched in tb. *)
-      else false
+  let reflexive_subset_domain_for_all2 f ta tb = subset_domain_for_all2 ~reflexive:true f ta tb
+  let nonreflexive_subset_domain_for_all2 f ta tb = subset_domain_for_all2 ~reflexive:false f ta tb
 
   type 'map polycompare =
       { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -465,8 +465,8 @@ module type BASE_MAP = sig
 
   type ('map1,'map2) polyfor_all2 =
     { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
-  val for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
-  (** [for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
+  val nonreflexive_any_domain_for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
+  (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
@@ -1372,8 +1372,8 @@ module type MAP_WITH_VALUE = sig
 
       @since v0.13.0  *)
 
-  val for_all2 : (key -> 'a value option -> 'b value option -> bool) -> 'a t -> 'b t -> bool
-  (** [for_all2 f m1 m2] is [true] if [f k v1_opt v2_opt] for all bindings [k]
+  val nonreflexive_any_domain_for_all2 : (key -> 'a value option -> 'b value option -> bool) -> 'a t -> 'b t -> bool
+  (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -1255,6 +1255,19 @@ module type MAP_WITH_VALUE = sig
       different.
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
+  val fold2 : (key -> 'a value option -> 'b value option -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+  (** [fold2 f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
+      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
+      bound in [m1] (resp [m2]).
+
+      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
+
   val filter : (key -> 'a value -> bool) -> 'a t -> 'a t
   (** Returns the submap containing only the key->value pairs satisfying the
       given predicate. [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
@@ -1355,6 +1368,18 @@ module type MAP_WITH_VALUE = sig
       Exits early if the domains mismatch or if [f] returns [false].
 
       @since v0.13.0  *)
+
+  val for_all2 : (key -> 'a value option -> 'b value option -> bool) -> 'a t -> 'b t -> bool
+  (** [for_all2 f m1 m2] is [true] if [f k v1_opt v2_opt] for all bindings [k]
+      in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
+
+      This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
+      which comes with no restriction about the domains of [m1] and [m2].
+
+      Calls [f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if [f] returns [false].
+
+      @since v0.13.0 *)
 
   val reflexive_equal: ('a value -> 'a value -> bool) -> 'a t -> 'a t -> bool
   (** [reflexive_equal f m1 m2] is true if both maps are equal, using [f] to compare values.

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -497,7 +497,7 @@ module type BASE_MAP = sig
   (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
-      Unlike {!reflexive_any_domain_for_all2}, this does not assume that [f.f] is reflexive
+      This is a slower version of {!reflexive_any_domain_for_all2}, it does not assume that [f.f] is reflexive
       and thus does not skip identical subtrees.
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
       which comes with no restriction about the domains of [m1] and [m2].
@@ -1433,7 +1433,7 @@ module type MAP_WITH_VALUE = sig
   (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
-      Unlike {!reflexive_any_domain_for_all2}, this does not assume that [f.f] is reflexive
+      This is a slower version of {!reflexive_any_domain_for_all2}, that does not assume that [f.f] is reflexive
       and thus does not skip identical subtrees.
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
       which comes with no restriction about the domains of [m1] and [m2].

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -416,7 +416,7 @@ module type BASE_MAP = sig
   (** [nonreflexive_same_domain_for_all2 f m1 m2] is the same as
       {!reflexive_same_domain_for_all2}, but doesn't assume [f.f] is reflexive.
       It thus calls [f.f] on every binding, in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-      Exits early if the domains mismatch or if [f.f] returns false. *)
+      Exits early if the domains mismatch or if [f.f] returns [false]. *)
 
   val reflexive_subset_domain_for_all2 :
     ('map,'map) polysame_domain_for_all2 -> 'map t -> 'map t -> bool
@@ -426,7 +426,7 @@ module type BASE_MAP = sig
 
       {b Assumes} [f.f] is reflexive, i.e. [f.f k v v = true] to skip calls to equal subtrees.
       Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-      Exits early if the domains mismatch.
+      Exits early if the domains mismatch or if [f.f] returns [false].
 
       It is useful to implement inclusion test on maps:
       {[
@@ -435,6 +435,18 @@ module type BASE_MAP = sig
           m1 m2;;
         val is_submap : 'a MyMap.t -> 'a MyMap.t -> bool = <fun>
       ]} *)
+
+  val nonreflexive_subset_domain_for_all2 :
+    ('map,'map) polysame_domain_for_all2 -> 'map t -> 'map t -> bool
+  (** [nonreflexive_subset_domain_for_all2 f m1 m2] is true if and only if
+      - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
+      - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
+
+      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f.f] is reflexive.
+      Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if the domains mismatch or if [f.f] returns [false].
+
+      @since v0.13.0  *)
 
   type 'map polycompare =
       { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]
@@ -1304,6 +1316,17 @@ module type MAP_WITH_VALUE = sig
       of [map1] and [map2]. The complexity is [O(log(n) * Delta)] where
       [Delta] is the number of different keys bound to different values in [map1] and
       [map2]. *)
+
+  val nonreflexive_subset_domain_for_all2 : (key -> 'a value -> 'a value -> bool) -> 'a t -> 'a t -> bool
+  (** [nonreflexive_subset_domain_for_all2 f m1 m2] is true if and only if
+      - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
+      - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f k v1 v2] holds
+
+      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f] is reflexive.
+      Calls [f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if the domains mismatch or if [f] returns [false].
+
+      @since v0.13.0  *)
 
   val reflexive_equal: ('a value -> 'a value -> bool) -> 'a t -> 'a t -> bool
   (** [reflexive_equal f m1 m2] is true if both maps are equal, using [f] to compare values.

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -287,8 +287,8 @@ module type BASE_MAP = sig
       where [(key_1, value_1) ... (key_n, value_n)] are the bindings of [m], in
       the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  type ('acc,'map) polyfold2 = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
-  val fold_on_nonequal_inter : ('acc,'map) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
+  type ('acc,'map) polyfold2_inter = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
+  val fold_on_nonequal_inter : ('acc,'map) polyfold2_inter -> 'map t -> 'map t -> 'acc -> 'acc
   (** [fold_on_nonequal_inter f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -296,14 +296,27 @@ module type BASE_MAP = sig
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
 
-  type ('acc,'map) polyfold2_union = { f: 'a. 'a key -> ('a,'map) value option -> ('a,'map) value option -> 'acc -> 'acc } [@@unboxed]
-  val fold_on_nonequal_union : ('acc,'map) polyfold2_union -> 'map t -> 'map t -> 'acc -> 'acc
+  type ('acc,'map1,'map2) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'acc -> 'acc } [@@unboxed]
+  val fold_on_nonequal_union : ('acc,'map,'map) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
   (** [fold_on_nonequal_union f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exists in either map ([m1 ∪ m2]) whose values are physically
       different.
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+
+  val fold2 : ('acc,'map1,'map2) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold2 f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
+      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
+      bound in [m1] (resp [m2]).
+
+      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   val filter : 'map polypredicate -> 'map t -> 'map t
@@ -437,7 +450,7 @@ module type BASE_MAP = sig
       ]} *)
 
   val nonreflexive_subset_domain_for_all2 :
-    ('map,'map) polysame_domain_for_all2 -> 'map t -> 'map t -> bool
+    ('map1,'map2) polysame_domain_for_all2 -> 'map1 t -> 'map2 t -> bool
   (** [nonreflexive_subset_domain_for_all2 f m1 m2] is true if and only if
       - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
@@ -447,6 +460,21 @@ module type BASE_MAP = sig
       Exits early if the domains mismatch or if [f.f] returns [false].
 
       @since v0.13.0  *)
+
+  type ('map1,'map2) polyfor_all2 =
+    { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
+  val for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
+  (** [for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
+      in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
+
+      This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
+      which comes with no restriction about the domains of [m1] and [m2].
+
+      Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if [f.f] returns [false].
+
+      @since v0.13.0 *)
+
 
   type 'map polycompare =
       { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -276,13 +276,12 @@ module type BASE_MAP = sig
 
       Where the order is given by the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  type 'map polyiter = { f : 'a. 'a key -> ('a, 'map) value -> unit; } [@@unboxed]
-  val iter : 'map polyiter -> 'map t -> unit
+  type ('map,'res) polyfold = { f: 'a. 'a key -> ('a,'map) value -> 'res } [@@unboxed]
+  val iter : ('map, unit) polyfold -> 'map t -> unit
   (** [iter f m] calls [f.f] on all bindings of [m],
       in the {{!unsigned_lt}unsigned order} on {!KEY.to_int} *)
 
-  type ('acc,'map) polyfold = { f: 'a. 'a key -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
-  val fold : ('acc,'map) polyfold -> 'map t -> 'acc -> 'acc
+  val fold : ('map, 'acc -> 'acc) polyfold -> 'map t -> 'acc -> 'acc
   (** [fold f m acc] returns [f.f key_n value_n (... (f.f key_1 value_1 acc))]
       where [(key_1, value_1) ... (key_n, value_n)] are the bindings of [m], in
       the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
@@ -295,9 +294,8 @@ module type BASE_MAP = sig
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-
-  type ('acc,'map1,'map2) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'acc -> 'acc } [@@unboxed]
-  val fold_on_nonequal_union : ('acc,'map,'map) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
+  type ('map1,'map2,'res) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
+  val fold_on_nonequal_union : ('map,'map,'acc->'acc) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
   (** [fold_on_nonequal_union f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -305,7 +303,7 @@ module type BASE_MAP = sig
       different.
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  val fold2 : ('acc,'map1,'map2) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  val fold2 : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold2 f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
       [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
       and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
@@ -317,6 +315,8 @@ module type BASE_MAP = sig
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since v0.13.0 *)
+
+  val iter2 : ('map1,'map2,unit) polyfold2 -> 'map1 t -> 'map2 t -> unit
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   val filter : 'map polypredicate -> 'map t -> 'map t
@@ -677,7 +677,7 @@ module type HETEROGENEOUS_MAP = sig
       - The type of {!key} is replaced by a type constructor ['k key].
         Because of that, most higher-order arguments require higher-ranking
         polymorphism, and we provide records that allows to
-        pass them as arguments (e.g. {!polyiter}, {!polymap}, {!polyunion}, etc.)
+        pass them as arguments (e.g. {!polyfold}, {!polymap}, {!polyunion}, etc.)
       - The type of the map ({!type:t}) is still parameterized by an argument (['m t])
       - The type of {!type:value} depend on both the type of the key and the
         type of the map, hence the type [('k,'m) value].
@@ -894,9 +894,8 @@ module type HETEROGENEOUS_SET = sig
       @since v0.11.0 *)
 
   (** {1 Iterators} *)
-
-  type polyiter = { f: 'a. 'a elt -> unit; } [@@unboxed]
-  val iter: polyiter -> t -> unit
+  type 'res polyfold = { f: 'a. 'a key  -> 'res } [@@unboxed]
+  val iter: unit polyfold -> t -> unit
   (** [iter f set] calls [f.f] on all elements of [set], in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   type polypredicate = { f: 'a. 'a elt -> bool; } [@@unboxed]
@@ -908,8 +907,7 @@ module type HETEROGENEOUS_SET = sig
   (** [for_all f set] is [true] if [f.f] is [true] on all elements of [set].
       Short-circuits on first [false]. [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  type 'acc polyfold = { f: 'a. 'a elt -> 'acc -> 'acc } [@@unboxed]
-  val fold: 'acc polyfold -> t -> 'acc -> 'acc
+  val fold: ('acc -> 'acc) polyfold -> t -> 'acc -> 'acc
   (** [fold f set acc] returns [f.f elt_n (... (f.f elt_1 acc) ...)], where
       [elt_1, ..., elt_n] are the elements of [set], in increasing {{!unsigned_lt}unsigned order} of
       {!KEY.to_int} *)

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -292,7 +292,21 @@ module type BASE_MAP = sig
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_inter : ('acc,'map1,'map2) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f.f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
+      [v1] and [v2].
+
+      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
 
   type ('map1,'map2,'res) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
   val fold_on_nonequal_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
@@ -301,10 +315,13 @@ module type BASE_MAP = sig
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exists in either map ([m1 ∪ m2]) whose values are physically
       different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
-  val fold2 : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
-  (** [fold2 f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+
+  val fold_on_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
       [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
       and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
       bound in [m1] (resp [m2]).
@@ -1264,7 +1281,21 @@ module type MAP_WITH_VALUE = sig
       [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
+      [v1] and [v2].
+
+      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
 
   val fold_on_nonequal_union: (key -> 'a value option -> 'b value option -> 'acc -> 'acc) ->
     'a t -> 'b t -> 'acc -> 'acc
@@ -1273,10 +1304,12 @@ module type MAP_WITH_VALUE = sig
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exists in either map ([m1 ∪ m2]) whose values are physically
       different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
-  val fold2 : (key -> 'a value option -> 'b value option -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
-  (** [fold2 f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_union : (key -> 'a value option -> 'b value option -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
       [f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
       and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
       bound in [m1] (resp [m2]).

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -899,7 +899,7 @@ module type HETEROGENEOUS_SET = sig
       @since v0.11.0 *)
 
   (** {1 Iterators} *)
-  type 'res polyfold = { f: 'a. 'a key  -> 'res } [@@unboxed]
+  type 'res polyfold = { f: 'a. 'a elt  -> 'res } [@@unboxed]
   val iter: unit polyfold -> t -> unit
   (** [iter f set] calls [f.f] on all elements of [set], in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -317,6 +317,11 @@ module type BASE_MAP = sig
       @since v0.13.0 *)
 
   val iter2 : ('map1,'map2,unit) polyfold2 -> 'map1 t -> 'map2 t -> unit
+  (** [iter2 f m1 m2] calls [f.f k v1_opt v2_opt] for every key [k]
+      in [m1] or [m2], with [v1_opt] (resp [v2_opt]) bound to the value of [k] in
+      [m1] (resp [m2]), or [None] if the value is absent.
+
+      @since v0.13.0 *)
 
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   val filter : 'map polypredicate -> 'map t -> 'map t
@@ -1265,6 +1270,13 @@ module type MAP_WITH_VALUE = sig
       skip physically equal bindings.
 
       Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
+
+  val iter2 : (key -> 'a value option -> 'b value option -> unit) -> 'a t -> 'b t -> unit
+  (** [iter2 f m1 m2] calls [f.f k v1_opt v2_opt] for every key [k]
+      in [m1] or [m2], with [v1_opt] (resp [v2_opt]) bound to the value of [k] in
+      [m1] (resp [m2]), or [None] if the value is absent.
 
       @since v0.13.0 *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -286,8 +286,8 @@ module type BASE_MAP = sig
       where [(key_1, value_1) ... (key_n, value_n)] are the bindings of [m], in
       the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  type ('acc,'map) polyfold2_inter = { f: 'a. 'a key -> ('a,'map) value -> ('a,'map) value -> 'acc -> 'acc } [@@unboxed]
-  val fold_on_nonequal_inter : ('acc,'map) polyfold2_inter -> 'map t -> 'map t -> 'acc -> 'acc
+  type ('acc,'map1,'map2) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc -> 'acc } [@@unboxed]
+  val fold_on_nonequal_inter : ('acc,'map1,'map2) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_nonequal_inter f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -295,7 +295,7 @@ module type BASE_MAP = sig
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   type ('map1,'map2,'res) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
-  val fold_on_nonequal_union : ('map,'map,'acc->'acc) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
+  val fold_on_nonequal_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_nonequal_union f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -470,10 +470,25 @@ module type BASE_MAP = sig
 
   type ('map1,'map2) polyfor_all2 =
     { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
+  val reflexive_any_domain_for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
+  (** [reflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
+      in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
+
+      {b Assumes} [f.f] is reflexive, i.e. [f.f k (Some v) (Some v) = true] to skip calls to equal subtrees.
+      Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if [f.f] returns [false].
+
+      This is a slower alternative to {!reflexive_same_domain_for_all2}/{!reflexive_subset_domain_for_all2},
+      which comes with no restriction about the domains of [m1] and [m2].
+
+      @since v0.13.0 *)
+
   val nonreflexive_any_domain_for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
   (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
+      Unlike {!reflexive_any_domain_for_all2}, this does not assume that [f.f] is reflexive
+      and thus does not skip identical subtrees.
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
       which comes with no restriction about the domains of [m1] and [m2].
 
@@ -1243,16 +1258,16 @@ module type MAP_WITH_VALUE = sig
   val fold : (key -> 'a value -> 'acc -> 'acc) ->  'a t -> 'acc -> 'acc
   (** Fold on each [(key,value)] pair of the map, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  val fold_on_nonequal_inter : (key -> 'a value -> 'a value -> 'acc -> 'acc) ->
-    'a t -> 'a t -> 'acc -> 'acc
+  val fold_on_nonequal_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) ->
+    'a t -> 'b t -> 'acc -> 'acc
   (** [fold_on_nonequal_inter f m1 m2 acc] returns
       [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
       Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  val fold_on_nonequal_union: (key -> 'a value option -> 'a value option -> 'acc -> 'acc) ->
-    'a t -> 'a t -> 'acc -> 'acc
+  val fold_on_nonequal_union: (key -> 'a value option -> 'b value option -> 'acc -> 'acc) ->
+    'a t -> 'b t -> 'acc -> 'acc
   (** [fold_on_nonequal_union f m1 m2 acc] returns
       [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -1382,10 +1397,25 @@ module type MAP_WITH_VALUE = sig
 
       @since v0.13.0  *)
 
+  val reflexive_any_domain_for_all2 : (key -> 'a value option -> 'b value option -> bool) -> 'a t -> 'b t -> bool
+  (** [reflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
+      in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
+
+      {b Assumes} [f.f] is reflexive, i.e. [f.f k (Some v) (Some v) = true] to skip calls to equal subtrees.
+      Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+      Exits early if [f.f] returns [false].
+
+      This is a slower alternative to {!reflexive_same_domain_for_all2}/{!reflexive_subset_domain_for_all2},
+      which comes with no restriction about the domains of [m1] and [m2].
+
+      @since v0.13.0 *)
+
   val nonreflexive_any_domain_for_all2 : (key -> 'a value option -> 'b value option -> bool) -> 'a t -> 'b t -> bool
   (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
+      Unlike {!reflexive_any_domain_for_all2}, this does not assume that [f.f] is reflexive
+      and thus does not skip identical subtrees.
       This is a slower alternative to {!nonreflexive_same_domain_for_all2}/{!nonreflexive_subset_domain_for_all2},
       which comes with no restriction about the domains of [m1] and [m2].
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -455,7 +455,9 @@ module type BASE_MAP = sig
       - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
 
-      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f.f] is reflexive.
+      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f.f] is reflexive
+      and thus does not skip identical subtrees.
+
       Calls [f.f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       Exits early if the domains mismatch or if [f.f] returns [false].
 
@@ -1363,7 +1365,8 @@ module type MAP_WITH_VALUE = sig
       - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f k v1 v2] holds
 
-      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f] is reflexive.
+      Unlike {!reflexive_subset_domain_for_all2}, this does not assume that [f] is reflexive,
+      and thus does not skip identical subtrees.
       Calls [f] in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       Exits early if the domains mismatch or if [f] returns [false].
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -333,13 +333,6 @@ module type BASE_MAP = sig
 
       @since v0.13.0 *)
 
-  val iter2 : ('map1,'map2,unit) polyfold2 -> 'map1 t -> 'map2 t -> unit
-  (** [iter2 f m1 m2] calls [f.f k v1_opt v2_opt] for every key [k]
-      in [m1] or [m2], with [v1_opt] (resp [v2_opt]) bound to the value of [k] in
-      [m1] (resp [m2]), or [None] if the value is absent.
-
-      @since v0.13.0 *)
-
   type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
   val filter : 'map polypredicate -> 'map t -> 'map t
   (** [filter f m] returns the submap of [m] containing the bindings [k->v]
@@ -1318,13 +1311,6 @@ module type MAP_WITH_VALUE = sig
       skip physically equal bindings.
 
       Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      @since v0.13.0 *)
-
-  val iter2 : (key -> 'a value option -> 'b value option -> unit) -> 'a t -> 'b t -> unit
-  (** [iter2 f m1 m2] calls [f.f k v1_opt v2_opt] for every key [k]
-      in [m1] or [m2], with [v1_opt] (resp [v2_opt]) bound to the value of [k] in
-      [m1] (resp [m2]), or [None] if the value is absent.
 
       @since v0.13.0 *)
 

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -166,6 +166,15 @@ let fold_on_nonequal_union f m0 m1 acc =
   let f acc k = f k (List.assoc_opt k m0) (List.assoc_opt k m1) acc in
   List.fold_left f acc keys
 
+let rec fold2 f m0 m1 acc = match m0, m1 with
+  | [], _ -> fold (fun k v acc -> f k None (Some v) acc) m1 acc
+  | _, [] -> fold (fun k v acc -> f k (Some v) None acc) m0 acc
+  | (k0,v0)::m0', (k1,v1)::m1' ->
+      match compare_keys k0 k1 with
+      | 0 -> fold2 f m0' m1' (f k0 (Some v0) (Some v1) acc)
+      | n when n < 0 -> fold2 f m0' m1 (f k0 (Some v0) None acc)
+      | _ -> fold2 f m0 m1' (f k1 None (Some v1) acc)
+
 let reflexive_same_domain_for_all2 p m0 m1 =
   let keys0 = keys m0
   and keys1 = keys m1
@@ -173,6 +182,9 @@ let reflexive_same_domain_for_all2 p m0 m1 =
   List.equal Int.equal keys0 keys1 && List.for_all p keys0
 
 let nonreflexive_same_domain_for_all2 = reflexive_same_domain_for_all2
+
+let for_all2 p m0 m1 =
+  List.for_all (fun k -> p k (List.assoc_opt k m0) (List.assoc_opt k m1)) (keys m0 @ keys m1)
 
 let difference f m0 m1 =
   let keys = keys @@ List.append m0 m1 in

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -153,6 +153,14 @@ let fold_on_nonequal_inter f m0 m1 acc =
       | _ -> acc)
     acc m0
 
+let fold_on_inter f m0 m1 acc =
+  List.fold_left
+    (fun acc (i, v0) ->
+      match List.assoc_opt i m1 with
+      | Some v1 -> f i v0 v1 acc
+      | _ -> acc)
+    acc m0
+
 let fold_on_nonequal_union f m0 m1 acc =
   (* Compute the nonequal union *)
   let p x =

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -183,7 +183,7 @@ let reflexive_same_domain_for_all2 p m0 m1 =
 
 let nonreflexive_same_domain_for_all2 = reflexive_same_domain_for_all2
 
-let for_all2 p m0 m1 =
+let nonreflexive_any_domain_for_all2 p m0 m1 =
   List.for_all (fun k -> p k (List.assoc_opt k m0) (List.assoc_opt k m1)) (keys m0 @ keys m1)
 
 let difference f m0 m1 =

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -192,6 +192,7 @@ let rec reflexive_subset_domain_for_all2 phi s t =
       let d = compare_keys x y in
       if d = 0 then phi x a b && reflexive_subset_domain_for_all2 phi xs ys
       else d > 0 && reflexive_subset_domain_for_all2 phi s ys
+let nonreflexive_subset_domain_for_all2 = reflexive_subset_domain_for_all2
 
 let intersect m0 m1 = idempotent_inter (fun _ l _ -> l) m0 m1 <> []
 

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -166,14 +166,14 @@ let fold_on_nonequal_union f m0 m1 acc =
   let f acc k = f k (List.assoc_opt k m0) (List.assoc_opt k m1) acc in
   List.fold_left f acc keys
 
-let rec fold2 f m0 m1 acc = match m0, m1 with
+let rec fold_on_union f m0 m1 acc = match m0, m1 with
   | [], _ -> fold (fun k v acc -> f k None (Some v) acc) m1 acc
   | _, [] -> fold (fun k v acc -> f k (Some v) None acc) m0 acc
   | (k0,v0)::m0', (k1,v1)::m1' ->
       match compare_keys k0 k1 with
-      | 0 -> fold2 f m0' m1' (f k0 (Some v0) (Some v1) acc)
-      | n when n < 0 -> fold2 f m0' m1 (f k0 (Some v0) None acc)
-      | _ -> fold2 f m0 m1' (f k1 None (Some v1) acc)
+      | 0 -> fold_on_union f m0' m1' (f k0 (Some v0) (Some v1) acc)
+      | n when n < 0 -> fold_on_union f m0' m1 (f k0 (Some v0) None acc)
+      | _ -> fold_on_union f m0 m1' (f k1 None (Some v1) acc)
 
 let reflexive_same_domain_for_all2 p m0 m1 =
   let keys0 = keys m0

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -376,14 +376,14 @@ let tests =
           Model.fold_on_nonequal_union
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
-    mk "fold2" two
+    mk "fold_on_union" two
       Print.(list (tup3 int (option char) (option char)))
       (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
-        ( Intmap.fold2
+        ( Intmap.fold_on_union
             (fun i a b acc -> (i, a, b) :: acc)
             t0 t1 [],
-          Model.fold2
+          Model.fold_on_union
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
     make_setop_test "nonidempotent_inter_no_share" idempotent_fst_or_snd snd

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -324,6 +324,10 @@ let tests =
       (fun3 O.int O.char O.char bool)
       Intmap.nonreflexive_subset_domain_for_all2
       Model.nonreflexive_subset_domain_for_all2;
+    make_setcmp_test "for_all2"
+      (fun3 O.int (O.option O.char) (O.option O.char) bool)
+      Intmap.for_all2
+      Model.for_all2;
     mk "intersect" (pair tree tree) Print.bool (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         (intersect t0 t1, Model.intersect (abstract t0) (abstract t1)));
@@ -370,6 +374,16 @@ let tests =
             (fun i a b acc -> (i, a, b) :: acc)
             t0 t1 [],
           Model.fold_on_nonequal_union
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
+    mk "fold2" two
+      Print.(list (tup3 int (option char) (option char)))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold2
+            (fun i a b acc -> (i, a, b) :: acc)
+            t0 t1 [],
+          Model.fold2
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
     make_setop_test "nonidempotent_inter_no_share" idempotent_fst_or_snd snd

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -320,6 +320,10 @@ let tests =
       (fun3 O.int O.char O.char bool)
       Intmap.reflexive_subset_domain_for_all2
       Model.reflexive_subset_domain_for_all2;
+    make_setcmp_test "nonreflexive_subset_domain_for_all2"
+      (fun3 O.int O.char O.char bool)
+      Intmap.nonreflexive_subset_domain_for_all2
+      Model.nonreflexive_subset_domain_for_all2;
     mk "intersect" (pair tree tree) Print.bool (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         (intersect t0 t1, Model.intersect (abstract t0) (abstract t1)));

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -324,10 +324,10 @@ let tests =
       (fun3 O.int O.char O.char bool)
       Intmap.nonreflexive_subset_domain_for_all2
       Model.nonreflexive_subset_domain_for_all2;
-    make_setcmp_test "for_all2"
+    make_setcmp_test "nonreflexive_any_domain_for_all2"
       (fun3 O.int (O.option O.char) (O.option O.char) bool)
-      Intmap.for_all2
-      Model.for_all2;
+      Intmap.nonreflexive_any_domain_for_all2
+      Model.nonreflexive_any_domain_for_all2;
     mk "intersect" (pair tree tree) Print.bool (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         (intersect t0 t1, Model.intersect (abstract t0) (abstract t1)));

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -366,6 +366,16 @@ let tests =
           Model.fold_on_nonequal_inter
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
+    mk "fold_on_inter" two
+      Print.(list (tup3 int char char))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold_on_inter
+            (fun i a b acc -> (i, a, b) :: acc)
+            t0 t1 [],
+          Model.fold_on_inter
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
     mk "fold_on_nonequal_union" two
       Print.(list (tup3 int (option char) (option char)))
       (fun (t0, t1) ->

--- a/test/property/patriciaTreeTest.ml
+++ b/test/property/patriciaTreeTest.ml
@@ -457,6 +457,15 @@ end) = struct
           myres = modelres)
   let () = QCheck.Test.check_exn test_nonreflexive_same_domain_for_all2
 
+  let test_nonreflexive_subset_domain_for_all2 = QCheck.Test.make ~count:1000 ~name:"nonreflexive_subset_domain_for_all2"
+      gen (fun x ->
+          let (m1,model1,m2,model2) = model_from_gen x in
+          let f _key a b = a <= b in  (* This is reflexive. *)
+          let myres = MyMap.nonreflexive_subset_domain_for_all2 f m1 m2 in
+          let modelres = IntMap.subset_domain_for_all_2 model1 model2 f in
+          myres = modelres)
+  let () = QCheck.Test.check_exn test_nonreflexive_same_domain_for_all2
+
   let test_idempotent_union = QCheck.Test.make ~count:1000 ~name:"idempotent_union"
       gen (fun x ->
           let (m1,model1,m2,model2) = model_from_gen x in


### PR DESCRIPTION
Following the discussion on https://git.frama-c.com/pub/frama-c/-/merge_requests/18, I've added some functions which could prove useful: `nonreflexive_subset_domain_for_all2`, `for_all2` and `fold2`.

I've also made a few refactoring changes. Using a polymorphic `phys_same` operator (which is just `==` with a more generic type (copied from core: https://github.com/janestreet/core/blob/4b7f751d84476a476e2e2551bf6f4f548cbde24b/core/src/std_internal.ml#L45), I was able to merge reflexive and nonreflexive implementations. I also added a physical equality check to difference to skip subtrees, as discussed.

EDIT: I added tests for all three functions.