### PR TITLE
Add nonidempotent_inter_filter_no_share

### DIFF
--- a/src/functors.ml
+++ b/src/functors.ml
@@ -850,6 +850,40 @@ module MakeCustomHeterogeneousMap
           else idempotent_inter_filter f ta tb1
         else empty
 
+  let rec nonidempotent_inter_filter_no_share
+      (f : ('a, 'b, 'c) polyinterfilter) ta tb =
+    match NODE.view ta,NODE.view tb with
+    | Empty, _ | _, Empty -> empty
+    | Leaf{key;value},_ ->
+      (try let res = find key tb in
+         match (f.f key value res) with
+         | Some v -> leaf key v
+         | None -> empty
+       with Not_found -> empty)
+    | _,Leaf{key;value} ->
+      (try let res = find key ta in
+         match f.f key res value with
+         | Some v -> leaf key v
+         | None -> empty
+       with Not_found -> empty)
+    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+      if ma == mb && pa == pb
+      (* Same prefix: merge the subtrees *)
+      then
+        let tree0 = nonidempotent_inter_filter_no_share f ta0 tb0 in
+        let tree1 = nonidempotent_inter_filter_no_share f ta1 tb1 in
+        branch ~prefix:pa ~branching_bit:ma ~tree0 ~tree1
+      else if branches_before pa ma pb mb
+      then if (ma :> int) land (pb :> int) == 0
+        then nonidempotent_inter_filter_no_share f ta0 tb
+        else nonidempotent_inter_filter_no_share f ta1 tb
+      else if branches_before pb mb pa ma
+      then if (mb :> int) land (pa :> int) == 0
+        then nonidempotent_inter_filter_no_share f ta tb0
+        else nonidempotent_inter_filter_no_share f ta tb1
+      else empty
+
   type ('map1,'map2,'map3) polymerge = { f: 'a. 'a Key.t -> ('a,'map1) Value.t option -> ('a,'map2) Value.t option -> ('a,'map3) Value.t option } [@@unboxed]
   let rec slow_merge: type mapa mapb mapc. (mapa,mapb,mapc) polymerge -> mapa NODE.t -> mapb NODE.t -> mapc NODE. t=
     fun f ta tb ->
@@ -1268,6 +1302,8 @@ module MakeCustomMap
     BaseMap.nonidempotent_inter_no_share {f=fun k (Snd v1) (Snd v2) -> Snd (f k v1 v2)} a b
   let idempotent_inter_filter (f: key -> 'a value -> 'a value -> 'a value option) a b =
     BaseMap.idempotent_inter_filter {f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2)} a b
+  let nonidempotent_inter_filter_no_share (f: key -> 'a value -> 'b value -> 'c value option) a b =
+    BaseMap.nonidempotent_inter_filter_no_share {f=fun k (Snd v1) (Snd v2) -> snd_opt (f k v1 v2)} a b
   let reflexive_same_domain_for_all2 (f: key -> 'a value -> 'a value -> bool) a b =
     BaseMap.reflexive_same_domain_for_all2 {f=fun k (Snd v1) (Snd v2) -> f k v1 v2} a b
   let nonreflexive_same_domain_for_all2 (f: key -> 'a value -> 'b value -> bool) a b =

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -529,11 +529,18 @@ module type BASE_MAP = sig
       [O(log(n)*i)] complexity, where [i] is the size of the intersection (number
       of keys bound in both maps). *)
 
-
   type ('map1, 'map2, 'map3) polyinterfilter = { f : 'a. 'a key -> ('a, 'map1) value -> ('a, 'map2) value -> ('a, 'map3) value option; } [@@unboxed]
   val idempotent_inter_filter : ('a, 'a, 'a) polyinterfilter -> 'a t -> 'a t -> 'a t
   (** [idempotent_inter_filter f map1 map2] is the same as {!idempotent_inter}
       but [f.f] can return [None] to remove a binding from the resutling map. *)
+
+  val nonidempotent_inter_filter_no_share : ('a, 'b, 'c) polyinterfilter -> 'a t -> 'b t -> 'c t
+  (** [nonidempotent_inter_filter_no_share f m1 m2] is like
+      {!nonidempotent_inter_no_share}, but it also removes the key->value
+      bindings for which [f] returns [None].
+      The complexity is [O(log(n)*i)] where [i] is the size of the intersection.
+      [f] is called on every elements of the intersection in increasing
+      {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   type ('map1, 'map2, 'map3) polymerge = {
     f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> ('a, 'map3) value option; } [@@unboxed]
@@ -1410,6 +1417,14 @@ module type MAP_WITH_VALUE = sig
       (assuming idempotence, using and preserving physically
       equal subtrees), but it also removes the key->value bindings for
       which [f] returns [None]. *)
+
+  val nonidempotent_inter_filter_no_share : (key -> 'a value -> 'b value -> 'c value option) -> 'a t -> 'b t -> 'c t
+  (** [nonidempotent_inter_filter_no_share f m1 m2] is like
+      {!nonidempotent_inter_no_share}, but it also removes the key->value
+      bindings for which [f] returns [None].
+      The complexity is [O(m)] where [m] is the size of the intersection.
+      [f] is called on every elements of the intersection in increasing
+      {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val slow_merge : (key -> 'a value option -> 'b value option -> 'c value option) -> 'a t -> 'b t -> 'c t
   (** [slow_merge f m1 m2] returns a map whose keys are a subset of the

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -21,7 +21,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-
 (** A naive model that we trust. Can be used both with QCheck (following Jan's
     paper) and Monolith *)
 
@@ -118,6 +117,7 @@ let idempotent_inter f m0 m1 =
   idempotent_inter_filter (fun i x y -> Some (f i x y)) m0 m1
 
 let nonidempotent_inter_no_share = idempotent_inter
+let nonidempotent_inter_filter_no_share = idempotent_inter_filter
 
 let symmetric_difference f m0 m1 =
   let keys = List.sort_uniq compare_keys @@ List.append (keys m0) (keys m1)

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -129,6 +129,17 @@ let nonidempotent_union_f =
       ("const", fun _ _ _ -> 'a');
     ]
 
+let nonidempotent_union_f_option =
+  oneof_list ~print:fst
+    [
+      ("fst", fun _ a _ -> Some a);
+      ("snd", fun _ _ b -> Some b);
+      ("const", fun _ _ _ -> Some 'a');
+      ("-> None", fun _ _ _ -> None);
+      ( "filter",
+        fun _ a _ -> if Char.code a < Char.code 'n' then Some a else None );
+    ]
+
 (* Like [idempotent_fst_or_snd] but with an extra [None] case. *)
 let idempotent_fst_or_snd_option =
   oneof_list ~print:fst
@@ -136,6 +147,8 @@ let idempotent_fst_or_snd_option =
       ("-> Some a", fun _ a _ -> Some a);
       ("-> Some b", fun _ _ b -> Some b);
       ("-> None", fun _ _ _ -> None);
+      ( "filter",
+        fun _ a _ -> if Char.code a < Char.code 'n' then Some a else None );
     ]
 
 let reflexive_same_domain_val =
@@ -302,6 +315,10 @@ let tests =
       Intmap.idempotent_inter Model.idempotent_inter;
     make_setop_test "idempotent_inter_filter" idempotent_fst_or_snd_option snd
       Intmap.idempotent_inter_filter Model.idempotent_inter_filter;
+    make_setop_test "nonidempotent_inter_filter_no_share"
+      nonidempotent_union_f_option snd
+      Intmap.nonidempotent_inter_filter_no_share
+      Model.nonidempotent_inter_filter_no_share;
     mk "reflexive_same_domain_for_all2" (pair reflexive_same_domain_val two)
       Print.bool (fun ((_, f), (t0, t1)) ->
         let t0 = interpret t0 and t1 = interpret t1 in


### PR DESCRIPTION
With the same intention as in https://github.com/codex-semantics-library/patricia-tree/pull/26 I propose to add `nonidempotent_inter_filter_no_share`, which is a common operation that can be implemented with `slow_merge`.

This operation can be easily implemented on the user side with `slow_merge` but adding it has the following advantages:

- The API is simpler and it is easier to call. This makes the user's code more readable by spelling out the name of the operation and by removing the optionnal argument handling.

- The implementation is faster by avoiding the traversal of subtrees with no intersection. The time complexity goes from O(n+m) to O(log(n)*i), where i is the size of the intersection.

The implementation is directly copied from `idempotent_inter_filter`, with the short circuiting checks removed.

If this is accepted, I'd also like to propose a non-reflexive `subset` and `iter2`.