### PR TITLE
Add fold_on_inter

### DIFF
--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1026,6 +1026,35 @@ module MakeCustomHeterogeneousMap
           else fold_on_nonequal_inter f ta tb1 acc
         else acc
 
+  let rec fold_on_inter f ta tb acc =
+    match NODE.view ta,NODE.view tb with
+    | Empty, _ | _, Empty -> acc
+    | Leaf{key;value},_ ->
+      (try let valueb = find key tb in
+           f.f key value valueb acc
+       with Not_found -> acc)
+    | _,Leaf{key;value} ->
+      (try let valuea = find key ta in
+           f.f key valuea value acc
+       with Not_found -> acc)
+    | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+      Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+      if ma == mb && pa == pb
+      (* Same prefix: fold on each subtrees *)
+      then
+        let acc = fold_on_inter f ta0 tb0 acc in
+        let acc = fold_on_inter f ta1 tb1 acc in
+        acc
+      else if branches_before pa ma pb mb
+      then if (ma :> int) land (pb :> int) == 0
+        then fold_on_inter f ta0 tb acc
+        else fold_on_inter f ta1 tb acc
+      else if branches_before pb mb pa ma
+      then if (mb :> int) land (pa :> int) == 0
+        then fold_on_inter f ta tb0 acc
+        else fold_on_inter f ta tb1 acc
+      else acc
+
 
   type ('acc,'map) polyfold2_union =
     { f: 'a. 'a key -> ('a,'map) value option -> ('a,'map) value option ->
@@ -1318,6 +1347,9 @@ module MakeCustomMap
   let fold_on_nonequal_inter (f: key -> 'a value -> 'a value -> 'acc -> 'acc) ma mb acc =
     let f k (Snd va) (Snd vb) acc = f k va vb acc in
     BaseMap.fold_on_nonequal_inter {f} ma mb acc
+  let fold_on_inter (f: key -> 'a value -> 'a value -> 'acc -> 'acc) ma mb acc =
+    let f k (Snd va) (Snd vb) acc = f k va vb acc in
+    BaseMap.fold_on_inter {f} ma mb acc
   let fold_on_nonequal_union
       (f: key -> 'a value option -> 'a value option -> 'acc -> 'acc) ma mb acc =
     let f k va vb acc =

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -295,6 +295,14 @@ module type BASE_MAP = sig
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
+  val fold_on_inter : ('acc,'map) polyfold2 -> 'map t -> 'map t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] returns
+      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exist in both maps ([m1 ∩ m2]). Unlike
+      [fold_on_nonequal_union], [f] is called for bindings whose values are
+      physically equal.
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   type ('acc,'map) polyfold2_union = { f: 'a. 'a key -> ('a,'map) value option -> ('a,'map) value option -> 'acc -> 'acc } [@@unboxed]
   val fold_on_nonequal_union : ('acc,'map) polyfold2_union -> 'map t -> 'map t -> 'acc -> 'acc
@@ -1214,6 +1222,16 @@ module type MAP_WITH_VALUE = sig
       [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
       bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
+
+  val fold_on_inter : (key -> 'a value -> 'a value -> 'acc -> 'acc) ->
+    'a t -> 'a t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] returns
+      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exist in both maps ([m1 ∩ m2]). Unlike
+      [fold_on_nonequal_union], [f] is called for bindings whose values are
+      physically equal.
       Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
   val fold_on_nonequal_union: (key -> 'a value option -> 'a value option -> 'acc -> 'acc) ->

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -153,6 +153,12 @@ let fold_on_nonequal_inter f m0 m1 acc =
       | _ -> acc)
     acc m0
 
+let fold_on_inter f m0 m1 acc =
+  List.fold_left
+    (fun acc (i, v0) ->
+      match List.assoc_opt i m1 with Some v1 -> f i v0 v1 acc | _ -> acc)
+    acc m0
+
 let fold_on_nonequal_union f m0 m1 acc =
   (* Compute the nonequal union *)
   let p x =

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -375,6 +375,14 @@ let tests =
           Model.fold_on_nonequal_inter
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
+    mk "fold_on_inter" two
+      Print.(list (tup3 int char char))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold_on_inter (fun i a b acc -> (i, a, b) :: acc) t0 t1 [],
+          Model.fold_on_inter
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
     mk "fold_on_nonequal_union" two
       Print.(list (tup3 int (option char) (option char)))
       (fun (t0, t1) ->


### PR DESCRIPTION
Iterate on the intersection between two maps without constructing a datastructure to hold it.

This is not equivalent to `fold_on_nonequal_inter` because the later removes bindings with physically equal values from the intersection. The result is not the intersection when the two maps share a common sub-tree:

    let a = PT.of_list [1, Some (); 2, Some ()]
    let b = PT.of_list [2, Some (); 3, Some ()]
    let c = PT.remove 1 a

    # PT.fold_on_nonequal_inter (fun k _ _ acc -> k :: acc) a b [] ;;
    - : PT.key list = [2]
    # PT.fold_on_nonequal_inter (fun k _ _ acc -> k :: acc) a c [] ;;
    - : PT.key list = []

It's hard to `fold_on_nonequal_inter` in existing code because we generally do not track which trees might share a common sub tree so we might resort to using `find` nested in a `for_all` or a `fold`, which is significantly slower.