### PR TITLE
Add JS implem of int_builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.14.0 - Unreleased
 
 - Change type of `nonreflexive_subset_domain_for_all2` to allows usage with maps of different type.
-- Add JS stubs for use with js-of-ocaml.
+- Add JS stubs for use with js-of-ocaml ([#34](https://github.com/codex-semantics-library/patricia-tree/pull/34)).
 
 # v0.13.0 - 2026-04-09
 
@@ -22,7 +22,7 @@
 - Specify that hash-consed and weak nodes are not thread safe (issue [#17](https://github.com/codex-semantics-library/patricia-tree/issues/17))
 - Add `MutexProtectNode` functors to enable multithreaded use of non-thread safe nodes ([#24](https://github.com/codex-semantics-library/patricia-tree/pull/24)).
 - Also add `Make[Heterogeneous]Hashconsed[Set|Map]WithMutex` functors using `MutexProtectNode`
-  for convenience  ([#24](https://github.com/codex-semantics-library/patricia-tree/pull/24)).
+  for convenience ([#24](https://github.com/codex-semantics-library/patricia-tree/pull/24)).
 - Fix a bug with `nonreflexive_same_domain_forall2` (by [julow](https://github.com/Julow) in [#19](https://github.com/codex-semantics-library/patricia-tree/pull/19))
 
 ## Dev changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.14.0 - Unreleased
 
 - Change type of `nonreflexive_subset_domain_for_all2` to allows usage with maps of different type.
+- Add JS stubs for use with js-of-ocaml.
 
 # v0.13.0 - 2026-04-09
 

--- a/src/dune
+++ b/src/dune
@@ -31,6 +31,8 @@
  (public_name patricia-tree)
  (instrumentation
   (backend bisect_ppx))
+ (js_of_ocaml
+  (javascript_files int_builtins.js))
  (foreign_stubs
   (language c)
   (names int_builtins)))

--- a/src/int_builtins.js
+++ b/src/int_builtins.js
@@ -22,6 +22,7 @@
 /* ************************************************************************ */
 
 // Implement the C stubs from int_builtins.c in JS
+//Provides: caml_int_builtin_highest_bit_byte
 function caml_int_builtin_highest_bit_byte(x) {
   if (x === 0) return 0;
   return 1 << (31 - Math.clz32(x));

--- a/src/int_builtins.js
+++ b/src/int_builtins.js
@@ -23,6 +23,6 @@
 
 // Implement the C stubs from int_builtins.c in JS
 function caml_int_builtin_highest_bit_byte(x) {
-  if (x < 0) return 1 << 31 // JS is 32 bit numbers
-  return 1 << Math.floor(Math.log2(x));
+  if (x === 0) return 0;
+  return 1 << (31 - Math.clz32(x));
 }

--- a/src/int_builtins.js
+++ b/src/int_builtins.js
@@ -1,0 +1,28 @@
+/* ************************************************************************ */
+/*   This file is part of the Codex semantics library                       */
+/*     (patricia-tree sub-component).                                       */
+/*                                                                          */
+/*                                                                          */
+/*   Copyright (C) 2013-2026                                                */
+/*     CEA (Commissariat à l'énergie atomique et aux énergies               */
+/*          alternatives)                                                   */
+/*                                                                          */
+/*   You can redistribute it and/or modify it under the terms of the GNU    */
+/*   Lesser General Public License as published by the Free Software        */
+/*   Foundation, version 2.1.                                               */
+/*                                                                          */
+/*   It is distributed in the hope that it will be useful,                  */
+/*   but WITHOUT ANY WARRANTY; without even the implied warranty of         */
+/*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          */
+/*   GNU Lesser General Public License for more details.                    */
+/*                                                                          */
+/*   See the GNU Lesser General Public License version 2.1                  */
+/*   for more details (enclosed in the file LICENSE).                       */
+/*                                                                          */
+/* ************************************************************************ */
+
+// Implement the C stubs from int_builtins.c in JS
+function caml_int_builtin_highest_bit_byte(x) {
+  if (x < 0) return 1 << 31 // JS is 32 bit numbers
+  return 1 << Math.floor(Math.log2(x));
+}

--- a/src/int_builtins.js
+++ b/src/int_builtins.js
@@ -22,7 +22,10 @@
 /* ************************************************************************ */
 
 // Implement the C stubs from int_builtins.c in JS
-//Provides: caml_int_builtin_highest_bit_byte
+// See https://ocsigen.org/js_of_ocaml/latest/manual/linker for how this works
+// as well as required annotations
+
+//Provides: caml_int_builtin_highest_bit_byte const
 function caml_int_builtin_highest_bit_byte(x) {
   if (x === 0) return 0;
   return 1 << (31 - Math.clz32(x));


### PR DESCRIPTION
This adds a JS implementation of the external C-stub we use, so our library can be used with JSOO (see #33).

Still needs some testing: the function itself should work but I don't know if there are integer boxing considerations around JSOO interface. I'll try to compile our tests to JS and run them.