### PR TITLE
Add `for_all2`, `fold2`, `exists2` and `iter2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.15.0 - Unreleased
+
+- Removed `polypredicate` types, as they can be expressed by `bool polyfold`
+
 # v0.14.0 - 2026-06-03
 
 - Change type of `nonreflexive_subset_domain_for_all2` to allows usage with maps of different type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Change type `polyfold2_inter` to use same convention as `polyfold2` (move res argument last, encode non-fold functions)
 - Removed `polysame_domain_for_all2`, `polyfor_all2` and `polycompare` types, as
   they can all be expressed with `polyfold2` or `polyfold2_inter`.
+- Removed `NODE_WITH_FIND` module type, as `WithForeign` can now operate directly
+  on `NODE`.
 
 # v0.14.0 - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v0.15.0 - Unreleased
 
 - Removed `polypredicate` types, as they can be expressed by `bool polyfold`
+- Change type `polyfold2_inter` to use same convention as `polyfold2` (move res argument last, encode non-fold functions)
+- Removed `polysame_domain_for_all2`, `polyfor_all2` and `polycompare` types, as
+  they can all be expressed with `polyfold2` or `polyfold2_inter`.
 
 # v0.14.0 - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.15.0 - Unreleased
 
-- Added `for_all2`, `exists2`, `fold2` and `iter2` functions
+- Added `for_all2`, `exists2`, `fold2` and `iter2` functions to maps and sets.
 - Removed `polypredicate` types, as they can be expressed by `bool polyfold`
 - Change type `polyfold2_inter` to use same convention as `polyfold2` (move res argument last, encode non-fold functions)
 - Removed `polysame_domain_for_all2`, `polyfor_all2` and `polycompare` types, as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.15.0 - Unreleased
 
+- Added `for_all2`, `exists2`, `fold2` and `iter2` functions
 - Removed `polypredicate` types, as they can be expressed by `bool polyfold`
 - Change type `polyfold2_inter` to use same convention as `polyfold2` (move res argument last, encode non-fold functions)
 - Removed `polysame_domain_for_all2`, `polyfor_all2` and `polycompare` types, as

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -39,6 +39,56 @@ let [@inline always] branches_before l_prefix (l_mask : mask) (r_prefix : intkey
 
 exception False
 
+module MakeCore(Key:HETEROGENEOUS_KEY)(Node: NODE with type 'a key = 'a Key.t) = struct
+  include Node
+  let rec findint: type a map. a key -> int -> map t -> (a,map) value =
+    fun witness searched m -> match Node.view m with
+      | Leaf{key;value} -> begin
+          match Key.polyeq key witness with
+          | Eq -> value
+          | Diff -> raise Not_found
+        end
+      | Branch{branching_bit;tree0;tree1;_} ->
+        (* Optional if not (match_prefix searched prefix branching_bit) then raise Not_found
+            else *) if ((branching_bit :> int) land searched == 0)
+        then findint witness searched tree0
+        else findint witness searched tree1
+      | Empty -> raise Not_found
+  let find searched m = findint searched (Key.to_int searched) m
+  let find_opt searched m = match find searched m with
+  | x -> Some x
+  | exception Not_found -> None
+
+    type ('map,'res) polyfold = { f: 'a. 'a key -> ('a,'map) Node.value -> 'res } [@@unboxed]
+
+    let rec fold f m acc = match Node.view m with
+      | Empty -> acc
+      | Leaf{key;value} -> f.f key value acc
+      | Branch{tree0;tree1;_} ->
+        let acc = fold f tree0 acc in
+        fold f tree1 acc
+
+    let rec for_all f m = match Node.view m with
+      | Empty -> true
+      | Leaf{key;value} -> f.f key value
+      | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
+
+    let forall_missing (type k') fmissing (fcommon: (k','a) Node.value option -> bool) (key: k' key) m =
+      let id_a = Key.to_int key in
+      let found = ref false in
+      let forall_func (type k) (keyb: k Key.t) valueb =
+        if !found then fmissing.f keyb valueb else
+        let id_b = Key.to_int keyb in
+        if unsigned_lt id_b id_a then fmissing.f keyb valueb
+        else
+          (found := true;
+          if unsigned_lt id_a id_b then fcommon None && fmissing.f keyb valueb
+          else match Key.polyeq key keyb with
+          | Eq -> fcommon (Some valueb)
+          | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
+      in for_all {f=forall_func} m
+end
+
 module MakeCustomHeterogeneousMap
     (Key:HETEROGENEOUS_KEY)
     (Value:HETEROGENEOUS_VALUE)
@@ -47,27 +97,7 @@ module MakeCustomHeterogeneousMap
     and type ('key,'map) value = ('key,'map) Value.t
     and type 'a t = 'a NODE.t
 = struct
-  module Core = struct
-    include NODE
-    let rec findint: type a map. a Key.t -> int -> map t -> (a,map) value =
-      fun witness searched m -> match NODE.view m with
-        | Leaf{key;value} -> begin
-            match Key.polyeq key witness with
-            | Eq -> value
-            | Diff -> raise Not_found
-          end
-        | Branch{branching_bit;tree0;tree1;_} ->
-          (* Optional if not (match_prefix searched prefix branching_bit) then raise Not_found
-             else *) if ((branching_bit :> int) land searched == 0)
-          then findint witness searched tree0
-          else findint witness searched tree1
-        | Empty -> raise Not_found
-    let find searched m = findint searched (Key.to_int searched) m
-    let find_opt searched m = match find searched m with
-    | x -> Some x
-    | exception Not_found -> None
-  end
-  include Core
+  include MakeCore(Key)(NODE)
 
   type 'map key_value_pair = KeyValue: 'a Key.t * ('a,'map) value -> 'map key_value_pair
 
@@ -214,45 +244,13 @@ module MakeCustomHeterogeneousMap
 
   let remove to_remove m = removeint (Key.to_int to_remove) m
 
-  module CorePlus(Map: NODE_WITH_FIND with type 'a key = 'a key) = struct
-    type ('map,'res) polyfold = { f: 'a. 'a Map.key -> ('a,'map) Map.value -> 'res } [@@unboxed]
-
-    let rec fold f m acc = match Map.view m with
-      | Empty -> acc
-      | Leaf{key;value} -> f.f key value acc
-      | Branch{tree0;tree1;_} ->
-        let acc = fold f tree0 acc in
-        fold f tree1 acc
-
-    let rec for_all f m = match Map.view m with
-      | Empty -> true
-      | Leaf{key;value} -> f.f key value
-      | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
-
-    let forall_missing (type k') fmissing (fcommon: (k','a) Map.value option -> bool) (key: k' key) m =
-      let id_a = Key.to_int key in
-      let found = ref false in
-      let forall_func (type k) (keyb: k Key.t) valueb =
-        if !found then fmissing.f keyb valueb else
-        let id_b = Key.to_int keyb in
-        if unsigned_lt id_b id_a then fmissing.f keyb valueb
-        else
-          (found := true;
-          if unsigned_lt id_a id_b then fcommon None && fmissing.f keyb valueb
-          else match Key.polyeq key keyb with
-          | Eq -> fcommon (Some valueb)
-          | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
-      in for_all {f=forall_func} m
-  end
-
-  include CorePlus(Core)
   let rec iter f x = match NODE.view x with
     | Empty -> ()
     | Leaf{key;value} -> f.f key value
     | Branch{tree0;tree1;_} -> iter f tree0; iter f tree1
 
-  module WithForeign(Map2:NODE_WITH_FIND with type 'a key = 'a key) = struct
-
+  module WithForeign(Map2:NODE with type 'a key = 'a key) = struct
+    module Core2 = MakeCore(Key)(Map2)
     (* Intersects the first map with the values of the second map,
        trying to preserve physical equality of the first map whenever
        possible. *)
@@ -261,7 +259,7 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta,Map2.view tb with
       | Empty, _ | _, Empty -> NODE.empty
       | Leaf{key;value},_ ->
-        (try let res = Map2.find key tb in
+        (try let res = Core2.find key tb in
            let newval = (f.f key value res) in
            if newval == value then ta
            else NODE.leaf key newval
@@ -356,7 +354,7 @@ module MakeCustomHeterogeneousMap
       | Empty, _ -> ta
       | _, Empty -> ta
       | Leaf{key;value},_ ->
-        begin match Map2.find key tb with
+        begin match Core2.find key tb with
         | exception Not_found -> ta
         | foundv -> begin
             match f.f key value foundv with
@@ -398,7 +396,7 @@ module MakeCustomHeterogeneousMap
       | _ when phys_same ta tb -> empty
       | Empty, _
       | _, Empty -> ta
-      | Leaf{key;value=va},_ -> (try let vb = Map2.find key tb in
+      | Leaf{key;value=va},_ -> (try let vb = Core2.find key tb in
             match f.f key va vb with
             | None -> empty
             | Some v -> if v == va then ta else leaf key v
@@ -427,7 +425,7 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta,Map2.view tb with
       | Empty, _ | _, Empty -> None
       | Leaf{key;value},_ ->
-        (try Some (KeyValueValue(key,value,Map2.find key tb))
+        (try Some (KeyValueValue(key,value,Core2.find key tb))
          with Not_found -> None)
       | _,Leaf{key;value} ->
         (try Some (KeyValueValue(key,find key ta,value))
@@ -454,7 +452,7 @@ module MakeCustomHeterogeneousMap
       match NODE.view ta, Map2.view tb with
       | Empty, _ | _, Empty -> None
       | Leaf{key;value},_ ->
-        (try Some (KeyValueValue(key,value,Map2.find key tb))
+        (try Some (KeyValueValue(key,value,Core2.find key tb))
           with Not_found -> None)
       | _,Leaf{key;value} ->
         (try Some (KeyValueValue(key,find key ta,value))
@@ -477,10 +475,8 @@ module MakeCustomHeterogeneousMap
           else max_binding_inter ta tb1
         else None
 
-
-    module CPL = CorePlus(Map2)
     (* Re-implement fold for Map2 *)
-    type ('map,'res) map2_polyfold = ('map,'res) CPL.polyfold = { f: 'a. 'a key -> ('a,'map) Map2.value -> 'res } [@@unboxed]
+    type ('map,'res) map2_polyfold = ('map,'res) Core2.polyfold = { f: 'a. 'a key -> ('a,'map) Map2.value -> 'res } [@@unboxed]
 
     type ('map1,'map2,'res) polyfold2 =
       { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) Map2.value option -> 'res } [@@unboxed]
@@ -513,7 +509,7 @@ module MakeCustomHeterogeneousMap
       let fright = match right_only with
         | True -> fun _ -> true
         | False -> fun _ -> false
-        | F f -> CPL.for_all {f=f.f} in
+        | F f -> Core2.for_all {f=f.f} in
       let reflexive = reflexive || common = True in
       let rec for_all2 ta tb =
         let same = phys_same ta tb in
@@ -531,10 +527,10 @@ module MakeCustomHeterogeneousMap
             end
           | Leaf{key;value},_ -> begin match right_only with
               | False -> false
-              | True -> (match Map2.find_opt key tb with
+              | True -> (match Core2.find_opt key tb with
                           | None -> of_l left_only key value
                           | Some v -> of_c common key value v)
-              | F f -> CPL.forall_missing f (fun v -> match v with
+              | F f -> Core2.forall_missing f (fun v -> match v with
                 | Some v -> of_c common key value v
                 | None -> of_l left_only key value
                ) key tb
@@ -579,7 +575,7 @@ module MakeCustomHeterogeneousMap
             else fright tb && fleft ta
       in for_all2
   end
-  include WithForeign(Core)
+  include WithForeign(NODE)
 
   let rec unsigned_min_binding x = match NODE.view x with
     | Empty -> raise Not_found
@@ -695,7 +691,7 @@ module MakeCustomHeterogeneousMap
       in loop t
     with Unmodified -> t
 
- (* Fast equality test between two maps. *)
+  (* Fast equality test between two maps. *)
   let rec same_domain_for_all2 ~reflexive (f : _ polyfold2_inter) ta tb = match (NODE.view ta),(NODE.view tb) with
     | _ when reflexive && phys_same ta tb -> true (* Skip same subtrees thanks to reflexivity. *)
     | Empty, Empty -> true
@@ -1454,7 +1450,7 @@ module MakeCustomMap
       f k va vb in
     BaseMap.reflexive_any_domain_for_all2 {f} ma mb
 
-  module WithForeign(Map2 : NODE_WITH_FIND with type _ key = key) = struct
+  module WithForeign(Map2 : NODE with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)
     type ('b,'c) polyfilter_map_foreign = { f: 'a. key -> ('a,'b) Map2.value -> 'c value option } [@@unboxed]
     let filter_map_no_share f m2 =

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1102,9 +1102,8 @@ module MakeCustomHeterogeneousMap
   let fold_on_nonequal_union f m1 m2 = fold_union ~reflexive:true f m1 m2
   let fold_on_union f m1 m2 = fold_union ~reflexive:false f m1 m2
 
-  type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
-  let filter f m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
-  let rec for_all f m = match NODE.view m with
+  let filter (f: (_,_) polyfold) m = filter_map {f = fun k v -> if f.f k v then Some v else None } m
+  let rec for_all (f: (_,_) polyfold) m = match NODE.view m with
     | Empty -> true
     | Leaf{key;value} -> f.f key value
     | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
@@ -1199,9 +1198,8 @@ module MakeCustomHeterogeneousSet
   let split k m = let (l, present, r) = BaseMap.split k m in
     (l, Option.is_some present, r)
 
-  type polypredicate = { f: 'a. 'a key -> bool; } [@@unboxed]
-  let filter f s = BaseMap.filter {f = fun k () -> f.f k } s
-  let for_all f s = BaseMap.for_all {f = fun k () -> f.f k} s
+  let filter (f : (_) polyfold) s = BaseMap.filter {f = fun k () -> f.f k } s
+  let for_all (f : (_) polyfold) s = BaseMap.for_all {f = fun k () -> f.f k} s
 
   let to_seq m = Seq.map (fun (KeyValue(elt,())) -> Any elt) (BaseMap.to_seq m)
   let to_rev_seq m = Seq.map (fun (KeyValue(elt,())) -> Any elt) (BaseMap.to_rev_seq m)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -695,9 +695,8 @@ module MakeCustomHeterogeneousMap
       in loop t
     with Unmodified -> t
 
-  type ('map1,'map2) polysame_domain_for_all2 = { f: 'a 'b. 'a Key.t -> ('a,'map1) Value.t -> ('a,'map2) Value.t -> bool } [@@unboxed]
-  (* Fast equality test between two maps. *)
-  let rec same_domain_for_all2 ~reflexive f ta tb = match (NODE.view ta),(NODE.view tb) with
+ (* Fast equality test between two maps. *)
+  let rec same_domain_for_all2 ~reflexive (f : _ polyfold2_inter) ta tb = match (NODE.view ta),(NODE.view tb) with
     | _ when reflexive && phys_same ta tb -> true (* Skip same subtrees thanks to reflexivity. *)
     | Empty, Empty -> true
     | Empty, _ | _, Empty -> false
@@ -716,7 +715,7 @@ module MakeCustomHeterogeneousMap
   let reflexive_same_domain_for_all2 f ta tb = same_domain_for_all2 ~reflexive:true f ta tb
   let nonreflexive_same_domain_for_all2 f ta tb = same_domain_for_all2 ~reflexive:false f ta tb
 
-  let rec subset_domain_for_all2 ~reflexive f ta tb = match (NODE.view ta),(NODE.view tb) with
+  let rec subset_domain_for_all2 ~reflexive (f : _ polyfold2_inter) ta tb = match (NODE.view ta),(NODE.view tb) with
     | _ when reflexive && phys_same ta tb -> true   (* Skip same subtrees thanks to reflexivity. *)
     | Empty, _ -> true
     | _, Empty -> false
@@ -756,10 +755,7 @@ module MakeCustomHeterogeneousMap
   let reflexive_subset_domain_for_all2 f ta tb = subset_domain_for_all2 ~reflexive:true f ta tb
   let nonreflexive_subset_domain_for_all2 f ta tb = subset_domain_for_all2 ~reflexive:false f ta tb
 
-  type 'map polycompare =
-      { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]
-
-  let compare_aux : type a b m. m polycompare -> a key -> (a,m) value -> b key -> (b,m) value -> int -> int =
+  let compare_aux : type a b m. (m,m,int) polyfold2_inter -> a key -> (a,m) value -> b key -> (b,m) value -> int -> int =
   fun f ka va kb vb default ->
     let cmp = Int.compare (Key.to_int ka) (Key.to_int kb) in
     if cmp <> 0 then cmp else
@@ -1230,12 +1226,10 @@ module MakeCustomHeterogeneousMap
     | Leaf{key;value} -> f.f key value
     | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
 
-  type ('map1,'map2) polyfor_all2 =
-    { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
-  let nonreflexive_any_domain_for_all2 f ta tb =
+  let nonreflexive_any_domain_for_all2 (f: _ polyfold2) ta tb =
     try fold_on_union {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
     with False -> false
-  let reflexive_any_domain_for_all2 f ta tb =
+  let reflexive_any_domain_for_all2 (f: _ polyfold2) ta tb =
     try fold_on_nonequal_union {f=fun k v1 v2 ()-> if f.f k v1 v2 then () else raise False} ta tb (); true
     with False -> false
 

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -86,10 +86,9 @@ module MakeCore(Key:HETEROGENEOUS_KEY)(Node: NODE with type 'a key = 'a Key.t) =
           else match Key.polyeq key keyb with
           | Eq -> fcommon (Some valueb)
           | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
-      in for_all {f=forall_func} m && (
-        if !found then true
-        else fcommon None
-      )
+      in
+      let res = for_all {f=forall_func} m in
+      res && if !found then true else fcommon None
 
     let fold_missing (type k') fmissing (fcommon: (k','a) Node.value option -> 'r -> 'r) (key: k' key) m r =
       let id_a = Key.to_int key in
@@ -106,8 +105,7 @@ module MakeCore(Key:HETEROGENEOUS_KEY)(Node: NODE with type 'a key = 'a Key.t) =
           | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
       in
       let r = fold {f=fold_func} m r in
-      if !found then r else
-      fcommon None r
+      if !found then r else fcommon None r
 end
 
 module MakeCustomHeterogeneousMap
@@ -511,10 +509,10 @@ module MakeCustomHeterogeneousMap
       | True -> true
       | False -> false
       | F f -> f.f k v
-    let of_c (f: (_,_,_) polyfold2_inter forall2_pred) k v v' = match f with
+    let of_c ~reflexive (f: (_,_,_) polyfold2_inter forall2_pred) k v v' = match f with
       | True -> true
       | False -> false
-      | F f -> f.f k v v'
+      | F f -> (reflexive && phys_same v v') || f.f k v v'
 
     let for_all2 :
       reflexive:bool ->
@@ -540,25 +538,25 @@ module MakeCustomHeterogeneousMap
           | Empty, _ -> fright tb
           | _, Empty -> fleft ta
           | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
-              | Diff -> if Key.to_int k < Key.to_int k'
+              | Diff -> if unsigned_lt (Key.to_int k) (Key.to_int k')
                         then of_l left_only k v && of_r right_only k' v'
                         else of_r right_only k' v' && of_l left_only k v
-              | Eq -> of_c common k v v' end
+              | Eq -> of_c ~reflexive common k v v' end
           | Leaf{key;value},_ -> begin match right_only with
               | False -> false
               | True -> (match Core2.find_opt key tb with
                           | None -> of_l left_only key value
-                          | Some v -> of_c common key value v)
+                          | Some v -> of_c ~reflexive common key value v)
               | F f -> Core2.forall_missing f (fun v -> match v with
-                | Some v -> of_c common key value v
+                | Some v -> of_c ~reflexive common key value v
                 | None -> of_l left_only key value) key tb end
           | _,Leaf{key;value} -> begin match left_only with
               | False -> false
               | True -> (match find_opt key ta with
                           | None -> of_r right_only key value
-                          | Some v -> of_c common key v value)
+                          | Some v -> of_c ~reflexive common key v value)
               | F f -> forall_missing f (fun v -> match v with
-                | Some v -> of_c common key v value
+                | Some v -> of_c ~reflexive common key v value
                 | None -> of_r right_only key value) key ta end
           | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
             Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
@@ -567,7 +565,7 @@ module MakeCustomHeterogeneousMap
             else if branches_before pa ma pb mb
             then if (ma :> int) land (pb :> int) == 0
               then for_all2 ta0 tb && fleft ta1
-              else fleft ta0 && for_all2 ta1 tb0
+              else fleft ta0 && for_all2 ta1 tb
             else if branches_before pb mb pa ma
             then if (mb :> int) land (pa :> int) == 0
               then for_all2 ta tb0 && fright tb1
@@ -596,9 +594,9 @@ module MakeCustomHeterogeneousMap
     let of_r (f: (_,_) map2_polyfold option) k v r = match f with
       | None -> r
       | Some f -> f.f k v r
-    let of_c (f: (_,_,_) polyfold2_inter option) k v v' r = match f with
+    let of_c ~reflexive (f: (_,_,_) polyfold2_inter option) k v v' r = match f with
       | None -> r
-      | Some f -> f.f k v v' r
+      | Some f -> if reflexive && phys_same v v' then r else f.f k v v' r
 
     let fold2 :
       reflexive:bool ->
@@ -620,23 +618,23 @@ module MakeCustomHeterogeneousMap
           | Empty, _ -> fright tb r
           | _, Empty -> fleft ta r
           | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
-              | Diff -> if Key.to_int k < Key.to_int k'
+              | Diff -> if unsigned_lt (Key.to_int k) (Key.to_int k')
                         then r |> of_l left_only k v |> of_r right_only k' v'
                         else r |> of_r right_only k' v' |> of_l left_only k v
-              | Eq -> of_c common k v v' r end
+              | Eq -> of_c ~reflexive common k v v' r end
           | Leaf{key;value},_ -> begin match right_only with
               | None -> (match Core2.find_opt key tb with
                           | None -> of_l left_only key value r
-                          | Some v -> of_c common key value v r)
+                          | Some v -> of_c ~reflexive common key value v r)
               | Some f -> Core2.fold_missing f (fun v -> match v with
-                | Some v -> of_c common key value v
+                | Some v -> of_c ~reflexive common key value v
                 | None -> of_l left_only key value) key tb r end
           | _,Leaf{key;value} -> begin match left_only with
               | None -> (match find_opt key ta with
                           | None -> of_r right_only key value r
-                          | Some v -> of_c common key v value r)
+                          | Some v -> of_c ~reflexive common key v value r)
               | Some f -> fold_missing f (fun v -> match v with
-                | Some v -> of_c common key v value
+                | Some v -> of_c ~reflexive common key v value
                 | None -> of_r right_only key value) key ta r end
           | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
             Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
@@ -645,7 +643,7 @@ module MakeCustomHeterogeneousMap
             else if branches_before pa ma pb mb
             then if (ma :> int) land (pb :> int) == 0
               then r |> fold2 ta0 tb |> fleft ta1
-              else r |> fleft ta0 |> fold2 ta1 tb0
+              else r |> fleft ta0 |> fold2 ta1 tb
             else if branches_before pb mb pa ma
             then if (mb :> int) land (pa :> int) == 0
               then r |> fold2 ta tb0 |> fright tb1

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -535,6 +535,7 @@ module MakeCustomHeterogeneousMap
         if same && reflexive then true
         else if same && common = False then false
         else match NODE.view ta, Map2.view tb with
+          | Empty, Empty -> true
           | Empty, _ -> fright tb
           | _, Empty -> fleft ta
           | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
@@ -792,7 +793,7 @@ module MakeCustomHeterogeneousMap
     | Leaf{key=keya;value=valuea}, Leaf{key=keyb;value=valueb} ->
       begin match Key.polyeq keya keyb with
         | Diff -> false
-        | Eq -> f.f keya valuea valueb
+        | Eq -> (reflexive && phys_same valuea valueb) || f.f keya valuea valueb
       end
     | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
       Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
@@ -817,7 +818,7 @@ module MakeCustomHeterogeneousMap
         | Leaf{key=keyb;value=valueb} ->
           begin match Key.polyeq keya keyb with
             | Diff -> false
-            | Eq -> f.f keya valuea valueb
+            | Eq -> (reflexive && phys_same valuea valueb) || f.f keya valuea valueb
           end
         | Branch{branching_bit;tree0;tree1;_} ->
           if ((branching_bit :> int) land searched == 0)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -515,16 +515,14 @@ module MakeCustomHeterogeneousMap
         let same = phys_same ta tb in
         if same && reflexive then true
         else if same && common = False then false
-        else
-          match NODE.view ta,Map2.view tb with
+        else match NODE.view ta, Map2.view tb with
           | Empty, _ -> fright tb
           | _, Empty -> fleft ta
           | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
               | Diff -> if Key.to_int k < Key.to_int k'
                         then of_l left_only k v && of_r right_only k' v'
                         else of_r right_only k' v' && of_l left_only k v
-              | Eq -> of_c common k v v'
-            end
+              | Eq -> of_c common k v v' end
           | Leaf{key;value},_ -> begin match right_only with
               | False -> false
               | True -> (match Core2.find_opt key tb with
@@ -532,9 +530,7 @@ module MakeCustomHeterogeneousMap
                           | Some v -> of_c common key value v)
               | F f -> Core2.forall_missing f (fun v -> match v with
                 | Some v -> of_c common key value v
-                | None -> of_l left_only key value
-               ) key tb
-            end
+                | None -> of_l left_only key value) key tb end
           | _,Leaf{key;value} -> begin match left_only with
               | False -> false
               | True -> (match find_opt key ta with
@@ -542,37 +538,24 @@ module MakeCustomHeterogeneousMap
                           | Some v -> of_c common key v value)
               | F f -> forall_missing f (fun v -> match v with
                 | Some v -> of_c common key v value
-                | None -> of_r right_only key value
-               ) key ta
-            end
+                | None -> of_r right_only key value) key ta end
           | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
             Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
             if ma == mb && pa == pb
-            (* Same prefix: merge the subtrees *)
-            then
-              for_all2 ta0 tb0 &&
-              for_all2 ta1 tb1
+            then for_all2 ta0 tb0 && for_all2 ta1 tb1 (* Same prefix: merge the subtrees *)
             else if branches_before pa ma pb mb
             then if (ma :> int) land (pb :> int) == 0
-              then
-                for_all2 ta0 tb &&
-                fleft ta1
-              else
-                fleft ta0 &&
-                for_all2 ta1 tb0
+              then for_all2 ta0 tb && fleft ta1
+              else fleft ta0 && for_all2 ta1 tb0
             else if branches_before pb mb pa ma
             then if (mb :> int) land (pa :> int) == 0
-              then
-                for_all2 ta tb0 &&
-                fright tb1
-              else
-                fright tb0 &&
-                for_all2 ta tb1
+              then for_all2 ta tb0 && fright tb1
+              else fright tb0 && for_all2 ta tb1
             else
-            (* Distinct subtrees: process them in increasing order of keys. *)
-            if unsigned_lt (pa :> int) (pb :> int)
-            then fleft ta && fright tb
-            else fright tb && fleft ta
+              (* Distinct subtrees: process them in increasing order of keys. *)
+              if unsigned_lt (pa :> int) (pb :> int)
+              then fleft ta && fright tb
+              else fright tb && fleft ta
       in for_all2
   end
   include WithForeign(NODE)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -214,6 +214,43 @@ module MakeCustomHeterogeneousMap
 
   let remove to_remove m = removeint (Key.to_int to_remove) m
 
+  module CorePlus(Map: NODE_WITH_FIND with type 'a key = 'a key) = struct
+    type ('map,'res) polyfold = { f: 'a. 'a Map.key -> ('a,'map) Map.value -> 'res } [@@unboxed]
+
+    let rec fold f m acc = match Map.view m with
+      | Empty -> acc
+      | Leaf{key;value} -> f.f key value acc
+      | Branch{tree0;tree1;_} ->
+        let acc = fold f tree0 acc in
+        fold f tree1 acc
+
+    let rec for_all f m = match Map.view m with
+      | Empty -> true
+      | Leaf{key;value} -> f.f key value
+      | Branch{tree0; tree1; _ } -> for_all f tree0 && for_all f tree1
+
+    let forall_missing (type k') fmissing (fcommon: (k','a) Map.value option -> bool) (key: k' key) m =
+      let id_a = Key.to_int key in
+      let found = ref false in
+      let forall_func (type k) (keyb: k Key.t) valueb =
+        if !found then fmissing.f keyb valueb else
+        let id_b = Key.to_int keyb in
+        if unsigned_lt id_b id_a then fmissing.f keyb valueb
+        else
+          (found := true;
+          if unsigned_lt id_a id_b then fcommon None && fmissing.f keyb valueb
+          else match Key.polyeq key keyb with
+          | Eq -> fcommon (Some valueb)
+          | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
+      in for_all {f=forall_func} m
+  end
+
+  include CorePlus(Core)
+  let rec iter f x = match NODE.view x with
+    | Empty -> ()
+    | Leaf{key;value} -> f.f key value
+    | Branch{tree0;tree1;_} -> iter f tree0; iter f tree1
+
   module WithForeign(Map2:NODE_WITH_FIND with type 'a key = 'a key) = struct
 
     (* Intersects the first map with the values of the second map,
@@ -439,6 +476,108 @@ module MakeCustomHeterogeneousMap
           then max_binding_inter ta tb0
           else max_binding_inter ta tb1
         else None
+
+
+    module CPL = CorePlus(Map2)
+    (* Re-implement fold for Map2 *)
+    type ('map,'res) map2_polyfold = ('map,'res) CPL.polyfold = { f: 'a. 'a key -> ('a,'map) Map2.value -> 'res } [@@unboxed]
+
+    type ('map1,'map2,'res) polyfold2 =
+      { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) Map2.value option -> 'res } [@@unboxed]
+    type ('map1,'map2,'acc) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) Map2.value -> 'acc } [@@unboxed]
+
+    let of_l (f: (_,_) polyfold forall2_pred) k v = match f with
+      | True -> true
+      | False -> false
+      | F f -> f.f k v
+    let of_r (f: (_,_) map2_polyfold forall2_pred) k v = match f with
+      | True -> true
+      | False -> false
+      | F f -> f.f k v
+    let of_c (f: (_,_,_) polyfold2_inter forall2_pred) k v v' = match f with
+      | True -> true
+      | False -> false
+      | F f -> f.f k v v'
+
+    let for_all2 :
+      reflexive:bool ->
+      left_only:('a,bool) polyfold forall2_pred ->
+      common:('a,'b,bool) polyfold2_inter forall2_pred ->
+      right_only:('b,bool) map2_polyfold forall2_pred ->
+      'a t -> 'b Map2.t -> bool
+    = fun ~reflexive ~left_only ~common ~right_only ->
+      let fleft = match left_only with
+        | True -> fun _ -> true
+        | False -> fun _ -> false
+        | F f -> for_all {f=f.f} in
+      let fright = match right_only with
+        | True -> fun _ -> true
+        | False -> fun _ -> false
+        | F f -> CPL.for_all {f=f.f} in
+      let reflexive = reflexive || common = True in
+      let rec for_all2 ta tb =
+        let same = phys_same ta tb in
+        if same && reflexive then true
+        else if same && common = False then false
+        else
+          match NODE.view ta,Map2.view tb with
+          | Empty, _ -> fright tb
+          | _, Empty -> fleft ta
+          | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
+              | Diff -> if Key.to_int k < Key.to_int k'
+                        then of_l left_only k v && of_r right_only k' v'
+                        else of_r right_only k' v' && of_l left_only k v
+              | Eq -> of_c common k v v'
+            end
+          | Leaf{key;value},_ -> begin match right_only with
+              | False -> false
+              | True -> (match Map2.find_opt key tb with
+                          | None -> of_l left_only key value
+                          | Some v -> of_c common key value v)
+              | F f -> CPL.forall_missing f (fun v -> match v with
+                | Some v -> of_c common key value v
+                | None -> of_l left_only key value
+               ) key tb
+            end
+          | _,Leaf{key;value} -> begin match left_only with
+              | False -> false
+              | True -> (match find_opt key ta with
+                          | None -> of_r right_only key value
+                          | Some v -> of_c common key v value)
+              | F f -> forall_missing f (fun v -> match v with
+                | Some v -> of_c common key v value
+                | None -> of_r right_only key value
+               ) key ta
+            end
+          | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+            Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+            if ma == mb && pa == pb
+            (* Same prefix: merge the subtrees *)
+            then
+              for_all2 ta0 tb0 &&
+              for_all2 ta1 tb1
+            else if branches_before pa ma pb mb
+            then if (ma :> int) land (pb :> int) == 0
+              then
+                for_all2 ta0 tb &&
+                fleft ta1
+              else
+                fleft ta0 &&
+                for_all2 ta1 tb0
+            else if branches_before pb mb pa ma
+            then if (mb :> int) land (pa :> int) == 0
+              then
+                for_all2 ta tb0 &&
+                fright tb1
+              else
+                fright tb0 &&
+                for_all2 ta tb1
+            else
+            (* Distinct subtrees: process them in increasing order of keys. *)
+            if unsigned_lt (pa :> int) (pb :> int)
+            then fleft ta && fright tb
+            else fright tb && fleft ta
+      in for_all2
   end
   include WithForeign(Core)
 
@@ -975,22 +1114,8 @@ module MakeCustomHeterogeneousMap
           else branch ~prefix:pb ~branching_bit:mb ~tree0:tb0 ~tree1:(symmetric_difference f ta tb1)
         else join (pa :> int) ta (pb :> int) tb
 
-  type ('map,'res) polyfold = { f: 'a. 'a key -> ('a,'map) value -> 'res } [@@unboxed]
-  let rec iter f x = match NODE.view x with
-    | Empty -> ()
-    | Leaf{key;value} -> f.f key value
-    | Branch{tree0;tree1;_} -> iter f tree0; iter f tree1
 
-  let rec fold f m acc = match NODE.view m with
-    | Empty -> acc
-    | Leaf{key;value} -> f.f key value acc
-    | Branch{tree0;tree1;_} ->
-      let acc = fold f tree0 acc in
-      fold f tree1 acc
-
-
-  type ('acc,'map1,'map2) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc -> 'acc } [@@unboxed]
-  let rec fold_inter ~reflexive f ta tb acc =
+  let rec fold_inter ~reflexive (f : (_,_,_) polyfold2_inter) ta tb acc =
     if reflexive && phys_same ta tb then acc
     else match NODE.view ta,NODE.view tb with
       | Empty, _ | _, Empty -> acc
@@ -1024,9 +1149,6 @@ module MakeCustomHeterogeneousMap
 
   let fold_on_nonequal_inter f m1 m2 = fold_inter ~reflexive:true f m1 m2
   let fold_on_inter f m1 m2 = fold_inter ~reflexive:false f m1 m2
-
-  type ('map1,'map2,'res) polyfold2 =
-    { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
 
   (** Intermediate function for folding on union, when folding on a leaf and a branch:
       Call fall on the branch and insert the correct call to leaf as needed. *)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1429,6 +1429,11 @@ let forall_pred_map f = function
   | False -> False
   | F x -> F (f x)
 
+let forall_pred_map_flip f = function
+  | True -> (False : _ forall2_pred)
+  | False -> True
+  | F x -> F (f x)
+
 module MakeCustomMap
     (Key:KEY)
     (Value: VALUE)
@@ -1554,6 +1559,28 @@ module MakeCustomMap
       ~left_only:(forall_pred_map (fun (f: key -> 'a value -> bool) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) left_only)
       ~common:(forall_pred_map (fun (f: key -> 'a value -> 'b value -> bool) -> ({f=fun k (Snd v) (Snd v') -> f k v v'} : _ BaseMap.polyfold2_inter )) common)
       ~right_only:(forall_pred_map (fun (f: key -> 'b value -> bool) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) right_only)
+
+  let exists2 ~reflexive ~left_only ~common ~right_only m1 m2 =
+    BaseMap.for_all2 ~reflexive
+      ~left_only:(forall_pred_map_flip (fun (f: key -> 'a value -> bool) -> ({f=fun k (Snd v) -> f k v |> not} : _ BaseMap.polyfold )) left_only)
+      ~common:(forall_pred_map_flip (fun (f: key -> 'a value -> 'b value -> bool) -> ({f=fun k (Snd v) (Snd v') -> f k v v' |> not} : _ BaseMap.polyfold2_inter )) common)
+      ~right_only:(forall_pred_map_flip (fun (f: key -> 'b value -> bool) -> ({f=fun k (Snd v) -> f k v |> not} : _ BaseMap.polyfold )) right_only)
+      m1 m2
+    |> not
+
+  let fold2 ~reflexive ~left_only ~common ~right_only =
+    BaseMap.fold2 ~reflexive
+      ~left_only:(Option.map (fun (f: key -> 'a value -> 'r -> 'r) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) left_only)
+      ~common:(Option.map (fun (f: key -> 'a value -> 'b value -> 'r -> 'r) -> ({f=fun k (Snd v) (Snd v') -> f k v v'} : _ BaseMap.polyfold2_inter )) common)
+      ~right_only:(Option.map (fun (f: key -> 'b value -> 'r -> 'r) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) right_only)
+
+  let iter2 ~reflexive ~left_only ~common ~right_only m1 m2 =
+    BaseMap.fold2 ~reflexive
+      ~left_only:(Option.map (fun (f: key -> 'a value -> unit) -> ({f=fun k (Snd v) () -> f k v} : _ BaseMap.polyfold )) left_only)
+      ~common:(Option.map (fun (f: key -> 'a value -> 'b value -> unit) -> ({f=fun k (Snd v) (Snd v') () -> f k v v'} : _ BaseMap.polyfold2_inter )) common)
+      ~right_only:(Option.map (fun (f: key -> 'b value -> unit) -> ({f=fun k (Snd v) () -> f k v} : _ BaseMap.polyfold )) right_only)
+      m1 m2 ()
+
 
   module WithForeign(Map2 : NODE with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -86,7 +86,28 @@ module MakeCore(Key:HETEROGENEOUS_KEY)(Node: NODE with type 'a key = 'a Key.t) =
           else match Key.polyeq key keyb with
           | Eq -> fcommon (Some valueb)
           | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
-      in for_all {f=forall_func} m
+      in for_all {f=forall_func} m && (
+        if !found then true
+        else fcommon None
+      )
+
+    let fold_missing (type k') fmissing (fcommon: (k','a) Node.value option -> 'r -> 'r) (key: k' key) m r =
+      let id_a = Key.to_int key in
+      let found = ref false in
+      let fold_func (type k) (keyb: k Key.t) valueb r =
+        if !found then fmissing.f keyb valueb r else
+        let id_b = Key.to_int keyb in
+        if unsigned_lt id_b id_a then fmissing.f keyb valueb r
+        else
+          (found := true;
+          if unsigned_lt id_a id_b then fcommon None r |> fmissing.f keyb valueb
+          else match Key.polyeq key keyb with
+          | Eq -> fcommon (Some valueb) r
+          | Diff -> raise (Invalid_argument "Keys with same to_int value are not equal by polyeq"))
+      in
+      let r = fold {f=fold_func} m r in
+      if !found then r else
+      fcommon None r
 end
 
 module MakeCustomHeterogeneousMap
@@ -557,6 +578,96 @@ module MakeCustomHeterogeneousMap
               then fleft ta && fright tb
               else fright tb && fleft ta
       in for_all2
+
+    let exists2 ~reflexive
+      ~(left_only:('a,bool) polyfold forall2_pred)
+      ~common
+      ~(right_only:('b,bool) map2_polyfold forall2_pred) m1 m2 =
+      for_all2 ~reflexive
+        ~left_only:(match left_only with True -> False | False -> True | F f -> F {f=fun k v -> f.f k v |> not})
+        ~common:(match common with True -> False | False -> True | F f -> F {f=fun k v1 v2 -> f.f k v1 v2 |> not})
+        ~right_only:(match right_only with True -> False | False -> True | F f -> F {f=fun k v -> f.f k v |> not})
+        m1 m2
+      |> not
+
+    let of_l (f: (_,_) polyfold option) k v r = match f with
+      | None -> r
+      | Some f -> f.f k v r
+    let of_r (f: (_,_) map2_polyfold option) k v r = match f with
+      | None -> r
+      | Some f -> f.f k v r
+    let of_c (f: (_,_,_) polyfold2_inter option) k v v' r = match f with
+      | None -> r
+      | Some f -> f.f k v v' r
+
+    let fold2 :
+      reflexive:bool ->
+      left_only:('a,'r -> 'r) polyfold option ->
+      common:('a,'b,'r -> 'r) polyfold2_inter option ->
+      right_only:('b,'r -> 'r) map2_polyfold option ->
+      'a t -> 'b Map2.t -> 'r -> 'r
+    = fun ~reflexive ~left_only ~common ~right_only ->
+      let fleft = match left_only with
+        | None -> fun _ -> Fun.id
+        | Some f -> fold {f=f.f} in
+      let fright = match right_only with
+        | None -> fun _ -> Fun.id
+        | Some f -> Core2.fold {f=f.f} in
+      let reflexive = reflexive || common = None in
+      let rec fold2 ta tb r =
+        if phys_same ta tb && reflexive then r
+        else match NODE.view ta, Map2.view tb with
+          | Empty, _ -> fright tb r
+          | _, Empty -> fleft ta r
+          | Leaf {key=k;value=v}, Leaf {key=k';value=v'} -> begin match Key.polyeq k k' with
+              | Diff -> if Key.to_int k < Key.to_int k'
+                        then r |> of_l left_only k v |> of_r right_only k' v'
+                        else r |> of_r right_only k' v' |> of_l left_only k v
+              | Eq -> of_c common k v v' r end
+          | Leaf{key;value},_ -> begin match right_only with
+              | None -> (match Core2.find_opt key tb with
+                          | None -> of_l left_only key value r
+                          | Some v -> of_c common key value v r)
+              | Some f -> Core2.fold_missing f (fun v -> match v with
+                | Some v -> of_c common key value v
+                | None -> of_l left_only key value) key tb r end
+          | _,Leaf{key;value} -> begin match left_only with
+              | None -> (match find_opt key ta with
+                          | None -> of_r right_only key value r
+                          | Some v -> of_c common key v value r)
+              | Some f -> fold_missing f (fun v -> match v with
+                | Some v -> of_c common key v value
+                | None -> of_r right_only key value) key ta r end
+          | Branch{prefix=pa;branching_bit=ma;tree0=ta0;tree1=ta1},
+            Branch{prefix=pb;branching_bit=mb;tree0=tb0;tree1=tb1} ->
+            if ma == mb && pa == pb
+            then r |> fold2 ta0 tb0 |> fold2 ta1 tb1 (* Same prefix: merge the subtrees *)
+            else if branches_before pa ma pb mb
+            then if (ma :> int) land (pb :> int) == 0
+              then r |> fold2 ta0 tb |> fleft ta1
+              else r |> fleft ta0 |> fold2 ta1 tb0
+            else if branches_before pb mb pa ma
+            then if (mb :> int) land (pa :> int) == 0
+              then r |> fold2 ta tb0 |> fright tb1
+              else r |> fright tb0 |> fold2 ta tb1
+            else
+              (* Distinct subtrees: process them in increasing order of keys. *)
+              if unsigned_lt (pa :> int) (pb :> int)
+              then r |> fleft ta |> fright tb
+              else r |> fright tb |> fleft ta
+      in fold2
+
+  let iter2 :
+      reflexive:bool ->
+      left_only:('a,unit) polyfold option ->
+      common:('a,'b,unit) polyfold2_inter option ->
+      right_only:('b,unit) map2_polyfold option -> _ =
+    fun ~reflexive ~left_only ~common ~right_only m1 m2 ->
+      fold2 ~reflexive
+        ~left_only:(match left_only with None -> None | Some f -> Some ({f = fun k v () -> f.f k v} ))
+        ~common:(Option.map (fun f -> {f = fun k v1 v2 () -> f.f k v1 v2}) common)
+        ~right_only:(match right_only with None -> None | Some f -> Some ({f = fun k v () -> f.f k v} ))
+        m1 m2 ()
   end
   include WithForeign(NODE)
 

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1313,6 +1313,11 @@ module MakeHeterogeneousMap(Key:HETEROGENEOUS_KEY)(Value:HETEROGENEOUS_VALUE) =
 module MakeHeterogeneousSet(Key:HETEROGENEOUS_KEY) =
   MakeCustomHeterogeneousSet(Key)(SetNode(Key))
 
+let forall_pred_map f = function
+  | True -> True
+  | False -> False
+  | F x -> F (f x)
+
 module MakeCustomMap
     (Key:KEY)
     (Value: VALUE)
@@ -1432,6 +1437,12 @@ module MakeCustomMap
       let vb = Option.map (fun (Snd v) -> v) vb in
       f k va vb in
     BaseMap.reflexive_any_domain_for_all2 {f} ma mb
+
+  let for_all2 ~reflexive ~left_only ~common ~right_only =
+    BaseMap.for_all2 ~reflexive
+      ~left_only:(forall_pred_map (fun (f: key -> 'a value -> bool) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) left_only)
+      ~common:(forall_pred_map (fun (f: key -> 'a value -> 'b value -> bool) -> ({f=fun k (Snd v) (Snd v') -> f k v v'} : _ BaseMap.polyfold2_inter )) common)
+      ~right_only:(forall_pred_map (fun (f: key -> 'b value -> bool) -> ({f=fun k (Snd v) -> f k v} : _ BaseMap.polyfold )) right_only)
 
   module WithForeign(Map2 : NODE with type _ key = key) = struct
     module BaseForeign = BaseMap.WithForeign(Map2)

--- a/src/functors.ml
+++ b/src/functors.ml
@@ -1342,6 +1342,16 @@ module MakeCustomHeterogeneousMap
   let to_list m = List.of_seq (to_seq m)
 end
 
+let forall_pred_map f = function
+  | True -> True
+  | False -> False
+  | F x -> F (f x)
+
+let forall_pred_map_flip f = function
+  | True -> (False : _ forall2_pred)
+  | False -> True
+  | F x -> F (f x)
+
 module MakeCustomHeterogeneousSet
     (Key:HETEROGENEOUS_KEY)
     (Node:NODE with type 'a key = 'a Key.t and type ('a, 'b) value = unit)
@@ -1393,6 +1403,34 @@ module MakeCustomHeterogeneousSet
   let pop_unsigned_maximum t = Option.map (fun (KeyValue(m,()),t) -> Any m,t) (BaseMap.pop_unsigned_maximum t)
   let pop_unsigned_minimum t = Option.map (fun (KeyValue(m,()),t) -> Any m,t) (BaseMap.pop_unsigned_minimum t)
 
+  let exists2 ~left_only ~(common: _ forall2_pred) ~right_only s1 s2 =
+    for_all2 ~reflexive:(common = False)
+      ~left_only:(forall_pred_map_flip (fun f -> ({f=fun k () -> f.f k |> not} : _ BaseMap.polyfold)) left_only)
+      ~common:(forall_pred_map_flip (fun f -> ({f=fun k () () -> f.f k |> not} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(forall_pred_map_flip (fun f -> ({f=fun k () -> f.f k |> not} : _ BaseMap.polyfold)) right_only)
+      s1 s2 |> not
+
+  let for_all2 ~left_only ~common ~right_only s1 s2 =
+    for_all2 ~reflexive:(common = True)
+      ~left_only:(forall_pred_map (fun f -> ({f=fun k () -> f.f k} : _ BaseMap.polyfold)) left_only)
+      ~common:(forall_pred_map (fun f -> ({f=fun k () () -> f.f k} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(forall_pred_map (fun f -> ({f=fun k () -> f.f k} : _ BaseMap.polyfold)) right_only)
+      s1 s2
+
+  let iter2 ~left_only ~common ~right_only s1 s2 =
+    fold2 ~reflexive:(common = None)
+      ~left_only:(Option.map (fun f -> ({f=fun k () () -> f.f k} : _ BaseMap.polyfold)) left_only)
+      ~common:(Option.map (fun f -> ({f=fun k () () () -> f.f k} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(Option.map (fun f -> ({f=fun k () () -> f.f k} : _ BaseMap.polyfold)) right_only)
+      s1 s2 ()
+
+  let fold2 ~left_only ~common ~right_only s1 s2 =
+    fold2 ~reflexive:(common = None)
+      ~left_only:(Option.map (fun f -> ({f=fun k () r -> f.f k r} : _ BaseMap.polyfold)) left_only)
+      ~common:(Option.map (fun f -> ({f=fun k () () r -> f.f k r} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(Option.map (fun f -> ({f=fun k () r -> f.f k r} : _ BaseMap.polyfold)) right_only)
+      s1 s2
+
   type polypretty = { f: 'a. Format.formatter -> 'a key -> unit; } [@@unboxed]
   let pretty ?pp_sep f fmt s = BaseMap.pretty ?pp_sep { f = fun fmt k () -> f.f fmt k} fmt s
 
@@ -1422,16 +1460,6 @@ module MakeHeterogeneousMap(Key:HETEROGENEOUS_KEY)(Value:HETEROGENEOUS_VALUE) =
 
 module MakeHeterogeneousSet(Key:HETEROGENEOUS_KEY) =
   MakeCustomHeterogeneousSet(Key)(SetNode(Key))
-
-let forall_pred_map f = function
-  | True -> True
-  | False -> False
-  | F x -> F (f x)
-
-let forall_pred_map_flip f = function
-  | True -> (False : _ forall2_pred)
-  | False -> True
-  | F x -> F (f x)
 
 module MakeCustomMap
     (Key:KEY)
@@ -1657,6 +1685,34 @@ module MakeCustomSet
   let of_seq s = add_seq s empty
   let of_list l = of_seq (List.to_seq l)
   let to_list s = List.of_seq (to_seq s)
+
+  let exists2 ~left_only ~(common: _ forall2_pred) ~right_only s1 s2 =
+    BaseMap.for_all2 ~reflexive:(common = False)
+      ~left_only:(forall_pred_map_flip (fun (f: elt -> bool) -> ({f=fun k () -> f k |> not} : _ BaseMap.polyfold)) left_only)
+      ~common:(forall_pred_map_flip (fun (f: elt -> bool) -> ({f=fun k () () -> f k |> not} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(forall_pred_map_flip (fun (f: elt -> bool) -> ({f=fun k () -> f k |> not} : _ BaseMap.polyfold)) right_only)
+      s1 s2 |> not
+
+  let for_all2 ~left_only ~common ~right_only s1 s2 =
+    BaseMap.for_all2 ~reflexive:(common = True)
+      ~left_only:(forall_pred_map (fun (f: elt -> bool) -> ({f=fun k () -> f k} : _ BaseMap.polyfold)) left_only)
+      ~common:(forall_pred_map (fun (f: elt -> bool) -> ({f=fun k () () -> f k} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(forall_pred_map (fun (f: elt -> bool) -> ({f=fun k () -> f k} : _ BaseMap.polyfold)) right_only)
+      s1 s2
+
+  let iter2 ~left_only ~common ~right_only s1 s2 =
+    BaseMap.fold2 ~reflexive:(common = None)
+      ~left_only:(Option.map (fun (f: elt -> unit) -> ({f=fun k () () -> f k} : _ BaseMap.polyfold)) left_only)
+      ~common:(Option.map (fun (f: elt -> unit) -> ({f=fun k () () () -> f k} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(Option.map (fun (f: elt -> unit) -> ({f=fun k () () -> f k} : _ BaseMap.polyfold)) right_only)
+      s1 s2 ()
+
+  let fold2 ~left_only ~common ~right_only s1 s2 =
+    BaseMap.fold2 ~reflexive:(common = None)
+      ~left_only:(Option.map (fun (f: elt -> 'r -> 'r) -> ({f=fun k () r -> f k r} : _ BaseMap.polyfold)) left_only)
+      ~common:(Option.map (fun (f: elt -> 'r -> 'r) -> ({f=fun k () () r -> f k r} : _ BaseMap.polyfold2_inter)) common)
+      ~right_only:(Option.map (fun (f: elt -> 'r -> 'r) -> ({f=fun k () r -> f k r} : _ BaseMap.polyfold)) right_only)
+      s1 s2
 end
 
 module MakeSet(Key: KEY) = MakeCustomSet(Key)(SetNode(HeterogeneousKeyFromKey(Key)))

--- a/src/functors.mli
+++ b/src/functors.mli
@@ -23,6 +23,14 @@
 
 open Signatures
 
+(** Type used to specify functions for {!MakeMap.for_all2} *)
+type 'a forall2_pred =
+  | True (** Equivalent to [F (fun _ -> true)], but allows skipping exploring the relevant cases *)
+  | False (** Equivalent to [F (fun _ -> false)], but allows skipping exploring the relevant cases *)
+  | F of 'a (** A user-supplied function *)
+
+
+
 (** This section presents the functors which can be used to build patricia tree
     maps and sets. *)
 

--- a/src/functors.mli
+++ b/src/functors.mli
@@ -23,14 +23,6 @@
 
 open Signatures
 
-(** Type used to specify functions for {!MakeMap.for_all2} *)
-type 'a forall2_pred =
-  | True (** Equivalent to [F (fun _ -> true)], but allows skipping exploring the relevant cases *)
-  | False (** Equivalent to [F (fun _ -> false)], but allows skipping exploring the relevant cases *)
-  | F of 'a (** A user-supplied function *)
-
-
-
 (** This section presents the functors which can be used to build patricia tree
     maps and sets. *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -661,6 +661,67 @@ val find : 'key key -> 'map t -> ('key, 'map) value
 
     @since v0.15.0 *)
 
+  val exists2:
+    reflexive:bool ->
+    left_only:('a,bool) polyfold forall2_pred ->
+    common:('a,'b,bool) polyfold2_inter forall2_pred ->
+    right_only:('b,bool) polyfold forall2_pred ->
+    'a t -> 'b t -> bool
+  (** Negation of {!for_all2}. While {!for_all2} early returns at the first
+      encountered [false] value. This early returns at the first encountered [true].
+      @since v0.15.0 *)
+
+  val fold2:
+    reflexive:bool ->
+    left_only:('a,'r -> 'r) polyfold option ->
+    common:('a,'b,'r -> 'r) polyfold2_inter option ->
+    right_only:('b,'r -> 'r) polyfold option ->
+    'a t -> 'b t -> 'r -> 'r
+  (** [fold2 ~reflexive ~left_only ~common ~right_only m1 m2 r] iterates two maps
+      [m1] and [m2] simultaneously, updating the accumulator [r] at each binding:
+      - [left_only k v1 r] is called on bindings [k -> v1] present in [m1] but not [m2];
+      - [right_only k v2 r] is called on bindings [k -> v2] present in [m2] but not [m1];
+      - [common k v1 v2 r] is called on shared bindings. If [reflexive] is set,
+        [common] is not called on physically equal bindings ([v1 == v2]).
+        This improves performance by skipping shared subtrees.
+
+      Each of these can be [None] instead of a function, in which case the corresponding
+      bindings are ignored. This can dramatically speed up the fold, as it then
+      skips exploration of unneeded subtrees.
+
+      [fold2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+    Some examples:
+    {ul
+    {- Fold only on non-equal shared bindings (aliases as {!fold_on_nonequal_inter}):
+       {@ocaml skip[
+          MyMap.fold2 ~reflexive:true
+            ~left_only:None ~right_only:None
+            ~common:(Some (fun k v1 v2 r -> ...))
+       ]}
+        }
+    {- Fold only on non-equal union bindings (aliases as {!fold_on_nonequal_union}),
+       via a single shared function [f] taking optional arguments for values:
+       {@ocaml skip[
+          MyMap.fold2 ~reflexive:true
+            ~left_only:(Some (fun k v1 r -> f k (Some v1) None r))
+            ~right_only:(Some (fun k v2 r -> f k None (Some v2) r))
+            ~common:(Some (fun k v1 v2 r -> f k (Some v1) (Some v2) r))
+       ]}
+    }}
+
+      @since v0.15.0 *)
+
+  val iter2:
+    reflexive:bool ->
+    left_only:('a, unit) polyfold option ->
+    common:('a,'b, unit) polyfold2_inter option ->
+    right_only:('b, unit) polyfold option ->
+    'a t -> 'b t -> unit
+  (** Calls the argument function on all bindings, just like {!fold2}.
+      Unlike {!fold2}, each function returns unit so no accumulator is threaded.
+      @since v0.15.0 *)
+
   val fold_on_nonequal_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_nonequal_inter f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
@@ -856,8 +917,35 @@ module type HETEROGENEOUS_MAP = sig
       common:('a,'b,bool) polyfold2_inter forall2_pred ->
       right_only:('b,bool) map2_polyfold forall2_pred ->
       'a t -> 'b Map2.t -> bool
-    (** Same as {!BASE_MAP.for_all2}, bur allowing the second map to have a different type.
+    (** Same as {!BASE_MAP.for_all2}, but allowing the second map to have a different type.
         @since v0.15.0 *)
+
+  val exists2:
+    reflexive:bool ->
+    left_only:('a,bool) polyfold forall2_pred ->
+    common:('a,'b,bool) polyfold2_inter forall2_pred ->
+    right_only:('b,bool) map2_polyfold forall2_pred ->
+    'a t -> 'b Map2.t -> bool
+  (** Same as {!BASE_MAP.exists2}, but allowing the second map to have a different type.
+      @since v0.15.0 *)
+
+  val fold2:
+    reflexive:bool ->
+    left_only:('a,'r -> 'r) polyfold option ->
+    common:('a,'b,'r -> 'r) polyfold2_inter option ->
+    right_only:('b,'r -> 'r) map2_polyfold option ->
+    'a t -> 'b Map2.t -> 'r -> 'r
+  (** Same as {!BASE_MAP.fold2}, but allowing the second map to have a different type.
+      @since v0.15.0 *)
+
+  val iter2:
+    reflexive:bool ->
+    left_only:('a, unit) polyfold option ->
+    common:('a,'b, unit) polyfold2_inter option ->
+    right_only:('b, unit) map2_polyfold option ->
+    'a t -> 'b Map2.t -> unit
+  (** Same as {!BASE_MAP.iter2}, but allowing the second map to have a different type.
+      @since v0.15.0 *)
   end
 end
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -1083,7 +1083,8 @@ module type HETEROGENEOUS_SET = sig
       @since v0.11.0 *)
 
   (** {1 Iterators} *)
-  type 'res polyfold = { f: 'a. 'a elt  -> 'res } [@@unboxed]
+
+  type 'res polyfold = { f: 'a. 'a elt -> 'res } [@@unboxed]
   val iter: unit polyfold -> t -> unit
   (** [iter f set] calls [f.f] on all elements of [set], in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
@@ -1105,6 +1106,65 @@ module type HETEROGENEOUS_SET = sig
     ?pp_sep:(Format.formatter -> unit -> unit) -> polypretty -> Format.formatter -> t -> unit
   (** Pretty prints the set, [pp_sep] is called once between each element,
       it defaults to {{: https://v2.ocaml.org/api/Format.html#VALpp_print_cut}[Format.pp_print_cut]} *)
+
+  (** {2 Iterators on pairs of sets} *)
+
+  val for_all2:
+    left_only:bool polyfold forall2_pred ->
+    common:bool polyfold forall2_pred ->
+    right_only:bool polyfold forall2_pred ->
+    t -> t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only s1 s2] evaluates
+    predicates on the elements of [s1] and [s2].
+    - [left_only k v1] is called for elements of [s1] that don't appear in [s2];
+    - [right_only k v2] is called for eleemnts of [s2] that don't appear in [s1];
+    - [common k v1 v2] is called for shared elements.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    [for_all2] explores elements in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
+
+  val exists2:
+    left_only:bool polyfold forall2_pred ->
+    common:bool polyfold forall2_pred ->
+    right_only:bool polyfold forall2_pred ->
+    t -> t -> bool
+  (** Negation of {!for_all2}. While {!for_all2} early returns at the first
+      encountered [false] value. This early returns at the first encountered [true].
+      @since v0.15.0 *)
+
+  val fold2:
+    left_only:('r -> 'r) polyfold option ->
+    common:('r -> 'r) polyfold option ->
+    right_only:('r -> 'r) polyfold option ->
+    t -> t -> 'r -> 'r
+  (** [fold2 ~reflexive ~left_only ~common ~right_only s1 s2 r] iterates two sets
+      [s1] and [s2] simultaneously, updating the accumulator [r] at each binding:
+      - [left_only x r] is called on elements [x] present in [s1] but not [s2];
+      - [right_only k v2 r] is called on elements present in [s2] but not [s1]
+      - [common k v1 v2 r] is called on shared elements.
+
+      Each of these can be [None] instead of a function, in which case the corresponding
+      bindings are ignored. This can dramatically speed up the fold, as it then
+      skips exploration of unneeded subtrees.
+
+      [fold2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.15.0 *)
+
+  val iter2:
+    left_only:unit polyfold option ->
+    common:unit polyfold option ->
+    right_only:unit polyfold option ->
+    t -> t -> unit
+  (** Calls the argument function on all bindings, just like {!fold2}.
+      Unlike {!fold2}, each function returns unit so no accumulator is threaded.
+      @since v0.15.0 *)
 
   (** {1 Conversion functions} *)
 
@@ -1228,6 +1288,66 @@ module type SET = sig
     (Format.formatter -> elt -> unit) -> Format.formatter -> t -> unit
   (** Pretty prints the set, [pp_sep] is called once between each element,
       it defaults to {{: https://v2.ocaml.org/api/Format.html#VALpp_print_cut}[Format.pp_print_cut]} *)
+
+
+  (** {2 Iterators on pairs of sets} *)
+
+  val for_all2:
+    left_only:(elt -> bool) forall2_pred ->
+    common:(elt -> bool) forall2_pred ->
+    right_only:(elt -> bool) forall2_pred ->
+    t -> t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only s1 s2] evaluates
+    predicates on the elements of [s1] and [s2].
+    - [left_only k v1] is called for elements of [s1] that don't appear in [s2];
+    - [right_only k v2] is called for eleemnts of [s2] that don't appear in [s1];
+    - [common k v1 v2] is called for shared elements.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    [for_all2] explores elements in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
+
+  val exists2:
+    left_only:(elt -> bool) forall2_pred ->
+    common:(elt -> bool) forall2_pred ->
+    right_only:(elt -> bool) forall2_pred ->
+    t -> t -> bool
+  (** Negation of {!for_all2}. While {!for_all2} early returns at the first
+      encountered [false] value. This early returns at the first encountered [true].
+      @since v0.15.0 *)
+
+  val fold2:
+    left_only:(elt -> 'r -> 'r) option ->
+    common:(elt -> 'r -> 'r) option ->
+    right_only:(elt -> 'r -> 'r) option ->
+    t -> t -> 'r -> 'r
+  (** [fold2 ~reflexive ~left_only ~common ~right_only s1 s2 r] iterates two sets
+      [s1] and [s2] simultaneously, updating the accumulator [r] at each binding:
+      - [left_only x r] is called on elements [x] present in [s1] but not [s2];
+      - [right_only k v2 r] is called on elements present in [s2] but not [s1]
+      - [common k v1 v2 r] is called on shared elements.
+
+      Each of these can be [None] instead of a function, in which case the corresponding
+      bindings are ignored. This can dramatically speed up the fold, as it then
+      skips exploration of unneeded subtrees.
+
+      [fold2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.15.0 *)
+
+  val iter2:
+    left_only:(elt -> unit) option ->
+    common:(elt -> unit) option ->
+    right_only:(elt -> unit) option ->
+    t -> t -> unit
+  (** Calls the argument function on all bindings, just like {!fold2}.
+      Unlike {!fold2}, each function returns unit so no accumulator is threaded.
+      @since v0.15.0 *)
 
   (** {1 Functions on pairs of sets} *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -25,11 +25,19 @@
 
 open Ints
 
-(** Type used to specify functions for {!MakeMap.for_all2} *)
+(** Type used to specify functions for {!MakeMap.for_all2}
+    @canonical PatriciaTree.forall2_pred *)
 type 'a forall2_pred =
-  | True (** Equivalent to [F (fun _ -> true)], but allows skipping exploring the relevant cases *)
-  | False (** Equivalent to [F (fun _ -> false)], but allows skipping exploring the relevant cases *)
-  | F of 'a (** A user-supplied function *)
+  | True
+    (** Equivalent to [F (fun _ -> true)], but allows skipping exploring the relevant cases
+        @canonical PatriciaTree.True *)
+
+  | False
+    (** Equivalent to [F (fun _ -> false)], but allows skipping exploring the relevant cases
+        @canonical PatriciaTree.False *)
+  | F of 'a
+    (** A user-supplied function
+        @canonical PatriciaTree.F *)
 
 (** {1 Nodes} *)
 (** Nodes are the underlying representation used to build a patricia-tree.
@@ -283,52 +291,6 @@ val find : 'key key -> 'map t -> ('key, 'map) value
       where [(key_1, value_1) ... (key_n, value_n)] are the bindings of [m], in
       the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  type ('map1,'map2,'acc) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc } [@@unboxed]
-  val fold_on_nonequal_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
-  (** [fold_on_nonequal_inter f m1 m2 acc] returns
-      [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
-      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
-      bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      Changed in v0.13.0 to allow argument maps of differing types. *)
-
-  val fold_on_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
-  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
-      [f.f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
-      [v1] and [v2].
-
-      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
-      skip physically equal bindings.
-
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      @since v0.13.0 *)
-
-  type ('map1,'map2,'res) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
-  val fold_on_nonequal_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
-  (** [fold_on_nonequal_union f m1 m2 acc] returns
-      [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
-      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
-      bindings that exists in either map ([m1 ∪ m2]) whose values are physically
-      different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      Changed in v0.13.0 to allow argument maps of differing types. *)
-
-  val fold_on_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
-  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
-      [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
-      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
-      bound in [m1] (resp [m2]).
-
-      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
-      skip physically equal bindings.
-
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      @since v0.13.0 *)
-
   val filter : ('map, bool) polyfold -> 'map t -> 'map t
   (** [filter f m] returns the submap of [m] containing the bindings [k->v]
       such that [f.f k v = true].
@@ -411,7 +373,10 @@ val find : 'key key -> 'map t -> ('key, 'map) value
       These is what the [polyXXX] types are for.*)
 
   (** {2 Comparing two maps} *)
+
   (** Functions for equality, inclusion, and test for disjointness. *)
+  type ('map1,'map2,'acc) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc } [@@unboxed]
+  type ('map1,'map2,'res) polyfold2 = { f: 'a. 'a key -> ('a,'map1) value option -> ('a,'map2) value option -> 'res } [@@unboxed]
 
   val reflexive_same_domain_for_all2 :
     ('map,'map,bool) polyfold2_inter -> 'map t -> 'map t -> bool
@@ -496,56 +461,6 @@ val find : 'key key -> 'map t -> ('key, 'map) value
       Exits early if [f.f] returns [false].
 
       @since v0.13.0 *)
-
-  val for_all2:
-    reflexive:bool ->
-    left_only:('a,bool) polyfold forall2_pred ->
-    common:('a,'b,bool) polyfold2_inter forall2_pred ->
-    right_only:('b,bool) polyfold forall2_pred ->
-    'a t -> 'b t -> bool
-  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
-    predicates on the bindings of [m1] and [m2].
-    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
-    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
-    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
-      If [reflexive] is [true], common is not called on physically equal bindings,
-      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
-
-    All three of these parameters can be either {!True}, {!False}, or a user supplied
-    function (using {!F}). The {!True} and {!False} constructors are faster, as
-    knowing these values in advance avoids having to explore the relevant branches.
-
-    Some examples:
-    {ul
-    {-
-      {@ocaml skip[
-        MyMap.for_all2 ~reflexive:true
-            ~left_only:False ~right_only:False
-            ~common:(F {f=fun _ -> MyValue.equal})
-      ]}
-      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2};}
-    {- {@ocaml skip[
-        MyMap.for_all2 ~reflexive:true
-            ~left_only:False ~right_only:True
-            ~common:(F {f=fun _ -> MyValue.equal})
-      ]}
-      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
-      Aliased as {!reflexive_subset_domain_for_all2}.}
-    {- {@ocaml[
-      MyMap.for_all2 ~reflexive:false
-        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
-        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
-        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
-        ]}
-        Calls a single function [f] on all bindings, using options to determine
-        whether the binding is present or known. Unlike the previous examples,
-        this will not skip any subparts of [m1] or [m2], and thus be slower.
-    }}
-
-    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-    It also has early-return: any false evaluation will stop exploration.
-
-    @since v0.15.0 *)
 
   val reflexive_compare : ('a,'a,int) polyfold2_inter -> 'a t -> 'a t -> int
   (** [reflexive_compare f m1 m2] is an order relation on maps.
@@ -693,6 +608,102 @@ val find : 'key key -> 'map t -> ('key, 'map) value
       nor keys bound to physically equal values).
 
       @since v0.11.0 *)
+
+  (** {2 Iterating two maps} *)
+
+  val for_all2:
+    reflexive:bool ->
+    left_only:('a,bool) polyfold forall2_pred ->
+    common:('a,'b,bool) polyfold2_inter forall2_pred ->
+    right_only:('b,bool) polyfold forall2_pred ->
+    'a t -> 'b t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
+    predicates on the bindings of [m1] and [m2].
+    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
+    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
+    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
+      If [reflexive] is [true], common is not called on physically equal bindings,
+      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    Some examples:
+    {ul
+    {-
+      {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:False
+            ~common:(F {f=fun _ -> MyValue.equal})
+      ]}
+      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2};}
+    {- {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:True
+            ~common:(F {f=fun _ -> MyValue.equal})
+      ]}
+      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
+      Aliased as {!reflexive_subset_domain_for_all2}.}
+    {- {@ocaml[
+      MyMap.for_all2 ~reflexive:false
+        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
+        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
+        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
+        ]}
+        Calls a single function [f] on all bindings, using options to determine
+        whether the binding is present or known. Unlike the previous examples,
+        this will not skip any subparts of [m1] or [m2], and thus be slower.
+    }}
+
+    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
+
+  val fold_on_nonequal_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_nonequal_inter f m1 m2 acc] returns
+      [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f.f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
+      [v1] and [v2].
+
+      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
+
+  val fold_on_nonequal_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_nonequal_union f m1 m2 acc] returns
+      [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exists in either map ([m1 ∪ m2]) whose values are physically
+      different.
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
+      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
+      bound in [m1] (resp [m2]).
+
+      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
 
   (** {2 Min/max of intersection} *)
 
@@ -1327,52 +1338,6 @@ module type MAP_WITH_VALUE = sig
   val fold : (key -> 'a value -> 'acc -> 'acc) ->  'a t -> 'acc -> 'acc
   (** Fold on each [(key,value)] pair of the map, in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  val fold_on_nonequal_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) ->
-    'a t -> 'b t -> 'acc -> 'acc
-  (** [fold_on_nonequal_inter f m1 m2 acc] returns
-      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
-      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
-      bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
-      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      Changed in v0.13.0 to allow argument maps of differing types. *)
-
-  val fold_on_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
-  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
-      [f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
-      [v1] and [v2].
-
-      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
-      skip physically equal bindings.
-
-      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      @since v0.13.0 *)
-
-  val fold_on_nonequal_union: (key -> 'a value option -> 'b value option -> 'acc -> 'acc) ->
-    'a t -> 'b t -> 'acc -> 'acc
-  (** [fold_on_nonequal_union f m1 m2 acc] returns
-      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
-      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
-      bindings that exists in either map ([m1 ∪ m2]) whose values are physically
-      different.
-      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      Changed in v0.13.0 to allow argument maps of differing types. *)
-
-  val fold_on_union : (key -> 'a value option -> 'b value option -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
-  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
-      [f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
-      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
-      bound in [m1] (resp [m2]).
-
-      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
-      skip physically equal bindings.
-
-      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-
-      @since v0.13.0 *)
-
   val filter : (key -> 'a value -> bool) -> 'a t -> 'a t
   (** Returns the submap containing only the key->value pairs satisfying the
       given predicate. [f] is called in increasing {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
@@ -1521,57 +1486,6 @@ module type MAP_WITH_VALUE = sig
       Assumes that [f v v = 0].
       @since v0.11.0 *)
 
-  val for_all2:
-    reflexive:bool ->
-    left_only:(key -> 'a value -> bool) forall2_pred ->
-    common:(key -> 'a value -> 'b value -> bool) forall2_pred ->
-    right_only:(key -> 'b value -> bool) forall2_pred ->
-    'a t -> 'b t -> bool
-  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
-    predicates on the bindings of [m1] and [m2].
-    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
-    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
-    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
-      If [reflexive] is [true], common is not called on physically equal bindings,
-      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
-
-    All three of these parameters can be either {!True}, {!False}, or a user supplied
-    function (using {!F}). The {!True} and {!False} constructors are faster, as
-    knowing these values in advance avoids having to explore the relevant branches.
-
-    Some examples:
-    {ul
-    {-
-      {@ocaml skip[
-        MyMap.for_all2 ~reflexive:true
-            ~left_only:False ~right_only:False
-            ~common:(F (fun _ -> MyValue.equal))
-      ]}
-      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2} or {!reflexive_equal};}
-    {- {@ocaml skip[
-        MyMap.for_all2 ~reflexive:true
-            ~left_only:False ~right_only:True
-            ~common:(F (fun _ -> MyValue.equal))
-      ]}
-      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
-      Aliased as {!reflexive_subset_domain_for_all2}.}
-    {- {@ocaml[
-      MyMap.for_all2 ~reflexive:false
-        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
-        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
-        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
-        ]}
-        Calls a single function [f: key -> 'a value option -> 'b value option -> bool]
-        on all bindings, using options to determine
-        whether the binding is present or known. Unlike the previous examples,
-        this will not skip any subparts of [m1] or [m2], and thus be slower.
-    }}
-
-    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
-    It also has early-return: any false evaluation will stop exploration.
-
-    @since v0.15.0 *)
-
   val disjoint : 'a t -> 'a t -> bool
   (** [disjoint a b] is [true] if and only if [a] and [b] have disjoint domains. *)
 
@@ -1703,6 +1617,105 @@ module type MAP_WITH_VALUE = sig
       [f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since v0.11.0 *)
+
+  (** {2 Iterating two maps} *)
+
+  val for_all2:
+    reflexive:bool ->
+    left_only:(key -> 'a value -> bool) forall2_pred ->
+    common:(key -> 'a value -> 'b value -> bool) forall2_pred ->
+    right_only:(key -> 'b value -> bool) forall2_pred ->
+    'a t -> 'b t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
+    predicates on the bindings of [m1] and [m2].
+    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
+    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
+    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
+      If [reflexive] is [true], common is not called on physically equal bindings,
+      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    Some examples:
+    {ul
+    {-
+      {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:False
+            ~common:(F (fun _ -> MyValue.equal))
+      ]}
+      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2} or {!reflexive_equal};}
+    {- {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:True
+            ~common:(F (fun _ -> MyValue.equal))
+      ]}
+      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
+      Aliased as {!reflexive_subset_domain_for_all2}.}
+    {- {@ocaml[
+      MyMap.for_all2 ~reflexive:false
+        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
+        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
+        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
+        ]}
+        Calls a single function [f: key -> 'a value option -> 'b value option -> bool]
+        on all bindings, using options to determine
+        whether the binding is present or known. Unlike the previous examples,
+        this will not skip any subparts of [m1] or [m2], and thus be slower.
+    }}
+
+    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
+
+  val fold_on_nonequal_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) ->
+    'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_nonequal_inter f m1 m2 acc] returns
+      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exist in both maps ([m1 ∩ m2]) whose values are physically different.
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
+      [v1] and [v2].
+
+      This is an alternative to {!fold_on_nonequal_inter}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
+
+  val fold_on_nonequal_union: (key -> 'a value option -> 'b value option -> 'acc -> 'acc) ->
+    'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_nonequal_union f m1 m2 acc] returns
+      [f key_n value1_n value2n (... (f key_1 value1_1 value2_1 acc))] where
+      [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
+      bindings that exists in either map ([m1 ∪ m2]) whose values are physically
+      different.
+      Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      Changed in v0.13.0 to allow argument maps of differing types. *)
+
+  val fold_on_union : (key -> 'a value option -> 'b value option -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+  (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
+      [f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
+      and [k,v2] in [m2]. [v1_opt] (resp [v2_opt]) will be [None] if [k] is not
+      bound in [m1] (resp [m2]).
+
+      This is an alternative to {!fold_on_nonequal_union}. It is slower but does not
+      skip physically equal bindings.
+
+      Calls to [f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+      @since v0.13.0 *)
 
   (** Combination with other kinds of maps.
       [Map2] must use the same {!KEY.to_int} function. *)

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -316,7 +316,6 @@ val find : 'key key -> 'map t -> ('key, 'map) value
 
       Changed in v0.13.0 to allow argument maps of differing types. *)
 
-
   val fold_on_union : ('map1,'map2,'acc->'acc) polyfold2 -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_union f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
       [f.f k v1_opt v2_opt acc] for each binding [k,v1] in [m1] ([v1_opt = Some v1])
@@ -329,7 +328,6 @@ val find : 'key key -> 'map t -> ('key, 'map) value
       Calls to [f.f] are performed in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
 
       @since v0.13.0 *)
-
 
   val filter : ('map, bool) polyfold -> 'map t -> 'map t
   (** [filter f m] returns the submap of [m] containing the bindings [k->v]
@@ -414,7 +412,6 @@ val find : 'key key -> 'map t -> ('key, 'map) value
 
   (** {2 Comparing two maps} *)
   (** Functions for equality, inclusion, and test for disjointness. *)
-
 
   val reflexive_same_domain_for_all2 :
     ('map,'map,bool) polyfold2_inter -> 'map t -> 'map t -> bool
@@ -506,6 +503,49 @@ val find : 'key key -> 'map t -> ('key, 'map) value
     common:('a,'b,bool) polyfold2_inter forall2_pred ->
     right_only:('b,bool) polyfold forall2_pred ->
     'a t -> 'b t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
+    predicates on the bindings of [m1] and [m2].
+    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
+    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
+    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
+      If [reflexive] is [true], common is not called on physically equal bindings,
+      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    Some examples:
+    {ul
+    {-
+      {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:False
+            ~common:(F {f=fun _ -> MyValue.equal})
+      ]}
+      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2};}
+    {- {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:True
+            ~common:(F {f=fun _ -> MyValue.equal})
+      ]}
+      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
+      Aliased as {!reflexive_subset_domain_for_all2}.}
+    {- {@ocaml[
+      MyMap.for_all2 ~reflexive:false
+        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
+        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
+        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
+        ]}
+        Calls a single function [f] on all bindings, using options to determine
+        whether the binding is present or known. Unlike the previous examples,
+        this will not skip any subparts of [m1] or [m2], and thus be slower.
+    }}
+
+    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
 
   val reflexive_compare : ('a,'a,int) polyfold2_inter -> 'a t -> 'a t -> int
   (** [reflexive_compare f m1 m2] is an order relation on maps.
@@ -805,6 +845,8 @@ module type HETEROGENEOUS_MAP = sig
       common:('a,'b,bool) polyfold2_inter forall2_pred ->
       right_only:('b,bool) map2_polyfold forall2_pred ->
       'a t -> 'b Map2.t -> bool
+    (** Same as {!BASE_MAP.for_all2}, bur allowing the second map to have a different type.
+        @since v0.15.0 *)
   end
 end
 
@@ -1478,6 +1520,57 @@ module type MAP_WITH_VALUE = sig
 
       Assumes that [f v v = 0].
       @since v0.11.0 *)
+
+  val for_all2:
+    reflexive:bool ->
+    left_only:(key -> 'a value -> bool) forall2_pred ->
+    common:(key -> 'a value -> 'b value -> bool) forall2_pred ->
+    right_only:(key -> 'b value -> bool) forall2_pred ->
+    'a t -> 'b t -> bool
+  (** [for_all2 ~reflexive ~left_only ~common ~right_only m1 m2] evaluates
+    predicates on the bindings of [m1] and [m2].
+    - [left_only k v1] is called for bindings [k -> v1] of [m1] ([k] does not appear in [m2]);
+    - [right_only k v2] is called for bindings [k -> v2] of [m2] ([k] does not appear in [m1]);
+    - [common k v1 v2] is called for shared binding [k -> v1] in [m1] and [k -> v2] in [m2].
+      If [reflexive] is [true], common is not called on physically equal bindings,
+      as they are assumed to be true. This speeds up the exploration, as shared subtrees are skipped.
+
+    All three of these parameters can be either {!True}, {!False}, or a user supplied
+    function (using {!F}). The {!True} and {!False} constructors are faster, as
+    knowing these values in advance avoids having to explore the relevant branches.
+
+    Some examples:
+    {ul
+    {-
+      {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:False
+            ~common:(F (fun _ -> MyValue.equal))
+      ]}
+      tests map equality (no unshared bindings), aliased as {!reflexive_same_domain_for_all2} or {!reflexive_equal};}
+    {- {@ocaml skip[
+        MyMap.for_all2 ~reflexive:true
+            ~left_only:False ~right_only:True
+            ~common:(F (fun _ -> MyValue.equal))
+      ]}
+      tests map inclusion (all bindings of [m1] are bindings of [m2], but [m2] can have extra bindings).
+      Aliased as {!reflexive_subset_domain_for_all2}.}
+    {- {@ocaml[
+      MyMap.for_all2 ~reflexive:false
+        ~left_only:(F {f=fun k v1 -> f k (Some v1) None})
+        ~right_only:(F {f=fun k v2 -> f k None (Some v2)})
+        ~common:(F {f=fun k v1 v2 -> f k (Some v1) (Some v2)})
+        ]}
+        Calls a single function [f: key -> 'a value option -> 'b value option -> bool]
+        on all bindings, using options to determine
+        whether the binding is present or known. Unlike the previous examples,
+        this will not skip any subparts of [m1] or [m2], and thus be slower.
+    }}
+
+    [for_all2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+    It also has early-return: any false evaluation will stop exploration.
+
+    @since v0.15.0 *)
 
   val disjoint : 'a t -> 'a t -> bool
   (** [disjoint a b] is [true] if and only if [a] and [b] have disjoint domains. *)

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -25,6 +25,12 @@
 
 open Ints
 
+(** Type used to specify functions for {!MakeMap.for_all2} *)
+type 'a forall2_pred =
+  | True (** Equivalent to [F (fun _ -> true)], but allows skipping exploring the relevant cases *)
+  | False (** Equivalent to [F (fun _ -> false)], but allows skipping exploring the relevant cases *)
+  | F of 'a (** A user-supplied function *)
+
 (** {1 Nodes} *)
 (** Nodes are the underlying representation used to build a patricia-tree.
     The module type specifies the constructors they must provide, and a common
@@ -286,8 +292,8 @@ module type BASE_MAP = sig
       where [(key_1, value_1) ... (key_n, value_n)] are the bindings of [m], in
       the {{!unsigned_lt}unsigned order} on {!KEY.to_int}. *)
 
-  type ('acc,'map1,'map2) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc -> 'acc } [@@unboxed]
-  val fold_on_nonequal_inter : ('acc,'map1,'map2) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  type ('map1,'map2,'acc) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) value -> 'acc } [@@unboxed]
+  val fold_on_nonequal_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_nonequal_inter f m1 m2 acc] returns
       [f.f key_n value1_n value2n (... (f.f key_1 value1_1 value2_1 acc))] where
       [(key_1, value1_1, value2_1) ... (key_n, value1_n, value2_n)] are the
@@ -296,7 +302,7 @@ module type BASE_MAP = sig
 
       Changed in v0.13.0 to allow argument maps of differing types. *)
 
-  val fold_on_inter : ('acc,'map1,'map2) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
+  val fold_on_inter : ('map1,'map2,'acc -> 'acc) polyfold2_inter -> 'map1 t -> 'map2 t -> 'acc -> 'acc
   (** [fold_on_inter f m1 m2 acc] iterates both maps [m1] and [m2] simultaneously, calling
       [f.f k v1 v2 acc] for each binding [k] in both [m1] and [m2], with respective values
       [v1] and [v2].
@@ -797,6 +803,17 @@ module type HETEROGENEOUS_MAP = sig
         the maximum key instead of the minimum.
 
         @since v0.11.0 *)
+
+    type ('map,'res) map2_polyfold = { f: 'a. 'a key -> ('a,'map) Map2.value -> 'res } [@@unboxed]
+
+    type ('map1,'map2,'acc) polyfold2_inter = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) Map2.value -> 'acc } [@@unboxed]
+
+    val for_all2:
+      reflexive:bool ->
+      left_only:('a,bool) polyfold forall2_pred ->
+      common:('a,'b,bool) polyfold2_inter forall2_pred ->
+      right_only:('b,bool) map2_polyfold forall2_pred ->
+      'a t -> 'b Map2.t -> bool
   end
 end
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -333,13 +333,13 @@ module type BASE_MAP = sig
 
       @since v0.13.0 *)
 
-  type 'map polypredicate = { f: 'a. 'a key -> ('a,'map) value -> bool; } [@@unboxed]
-  val filter : 'map polypredicate -> 'map t -> 'map t
+
+  val filter : ('map, bool) polyfold -> 'map t -> 'map t
   (** [filter f m] returns the submap of [m] containing the bindings [k->v]
       such that [f.f k v = true].
       [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int} *)
 
-  val for_all : 'map polypredicate -> 'map t -> bool
+  val for_all : ('map, bool) polyfold -> 'map t -> bool
   (** [for_all f m] checks that [f] holds on all bindings of [m].
       Short-circuiting. *)
 
@@ -938,12 +938,11 @@ module type HETEROGENEOUS_SET = sig
   val iter: unit polyfold -> t -> unit
   (** [iter f set] calls [f.f] on all elements of [set], in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  type polypredicate = { f: 'a. 'a elt -> bool; } [@@unboxed]
-  val filter: polypredicate -> t -> t
+  val filter: bool polyfold -> t -> t
   (** [filter f set] is the subset of [set] that only contains the elements that
       satisfy [f.f]. [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 
-  val for_all: polypredicate -> t -> bool
+  val for_all: bool polyfold -> t -> bool
   (** [for_all f set] is [true] if [f.f] is [true] on all elements of [set].
       Short-circuits on first [false]. [f.f] is called in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}. *)
 

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -169,22 +169,6 @@ module type HASH_CONSED_NODE = sig
       child nodes will always have a smaller identifier than their parents. *)
 end
 
-(** A {!NODE} along with its {!NODE_WITH_FIND.find} function.
-    This is the minimal argument to the {!HETEROGENEOUS_MAP.WithForeign} functors
-
-    @since v0.11.0
-    @canonical PatriciaTree.NODE_WITH_FIND *)
-module type NODE_WITH_FIND = sig
-  include NODE (** @closed *)
-
-  val find : 'key key -> 'map t -> ('key, 'map) value
-  (** [find key map] returns the value associated with [key] in [map] if present.
-      @raises Not_found if [key] is absent from map *)
-
-  val find_opt : 'key key -> 'map t -> ('key, 'map) value option
-  (** Same as {!find}, but returns [None] for Not_found *)
-end
-
 (** {1 Map signatures} *)
 
 (** {2 Base map} *)
@@ -203,7 +187,14 @@ end
 
     @canonical PatriciaTree.BASE_MAP *)
 module type BASE_MAP = sig
-  include NODE_WITH_FIND (** @open *)
+  include NODE (** @open *)
+
+val find : 'key key -> 'map t -> ('key, 'map) value
+  (** [find key map] returns the value associated with [key] in [map] if present.
+      @raises Not_found if [key] is absent from map *)
+
+  val find_opt : 'key key -> 'map t -> ('key, 'map) value option
+  (** Same as {!find}, but returns [None] for Not_found *)
 
   (** Existential wrapper for the ['a] parameter in a ['a key], [('a,'map) value] pair *)
   type 'map key_value_pair =
@@ -736,7 +727,7 @@ module type HETEROGENEOUS_MAP = sig
 
   (** Operation with maps/set of different types.
       [Map2] must use the same {!KEY.to_int} function. *)
-  module WithForeign(Map2: NODE_WITH_FIND with type 'a key = 'a key):sig
+  module WithForeign(Map2: NODE with type 'a key = 'a key):sig
     type ('map1,'map2) polyinter_foreign = { f: 'a. 'a key -> ('a,'map1) value -> ('a,'map2) Map2.value -> ('a,'map1) value } [@@unboxed]
 
     val nonidempotent_inter : ('a,'b) polyinter_foreign -> 'a t -> 'b Map2.t -> 'a t
@@ -1622,7 +1613,7 @@ module type MAP_WITH_VALUE = sig
 
   (** Combination with other kinds of maps.
       [Map2] must use the same {!KEY.to_int} function. *)
-  module WithForeign(Map2: NODE_WITH_FIND with type _ key = key):sig
+  module WithForeign(Map2: NODE with type _ key = key):sig
 
     type ('b,'c) polyfilter_map_foreign = { f: 'a. key -> ('a,'b) Map2.value -> 'c value option } [@@unboxed]
     val filter_map_no_share : ('b, 'c) polyfilter_map_foreign -> 'b Map2.t ->  'c t

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -609,7 +609,7 @@ val find : 'key key -> 'map t -> ('key, 'map) value
 
       @since v0.11.0 *)
 
-  (** {2 Iterating two maps} *)
+  (** {2 Iterating on two maps} *)
 
   val for_all2:
     reflexive:bool ->
@@ -697,16 +697,16 @@ val find : 'key key -> 'map t -> ('key, 'map) value
        {@ocaml skip[
           MyMap.fold2 ~reflexive:true
             ~left_only:None ~right_only:None
-            ~common:(Some (fun k v1 v2 r -> ...))
+            ~common:(Some {f=fun k v1 v2 r -> ...})
        ]}
         }
     {- Fold only on non-equal union bindings (aliases as {!fold_on_nonequal_union}),
        via a single shared function [f] taking optional arguments for values:
        {@ocaml skip[
           MyMap.fold2 ~reflexive:true
-            ~left_only:(Some (fun k v1 r -> f k (Some v1) None r))
-            ~right_only:(Some (fun k v2 r -> f k None (Some v2) r))
-            ~common:(Some (fun k v1 v2 r -> f k (Some v1) (Some v2) r))
+            ~left_only:(Some {f=fun k v1 r -> f k (Some v1) None r})
+            ~right_only:(Some {f=fun k v2 r -> f k None (Some v2) r})
+            ~common:(Some {f=fun k v1 v2 r -> f k (Some v1) (Some v2) r})
        ]}
     }}
 
@@ -1706,7 +1706,7 @@ module type MAP_WITH_VALUE = sig
 
       @since v0.11.0 *)
 
-  (** {2 Iterating two maps} *)
+  (** {2 Iterating on two maps} *)
 
   val for_all2:
     reflexive:bool ->
@@ -1758,6 +1758,68 @@ module type MAP_WITH_VALUE = sig
     It also has early-return: any false evaluation will stop exploration.
 
     @since v0.15.0 *)
+
+
+  val exists2:
+    reflexive:bool ->
+    left_only:(key -> 'a value -> bool) forall2_pred ->
+    common:(key -> 'a value -> 'b value -> bool) forall2_pred ->
+    right_only:(key -> 'b value -> bool) forall2_pred ->
+    'a t -> 'b t -> bool
+  (** Negation of {!for_all2}. While {!for_all2} early returns at the first
+      encountered [false] value. This early returns at the first encountered [true].
+      @since v0.15.0 *)
+
+  val fold2:
+    reflexive:bool ->
+    left_only:(key -> 'a value -> 'r -> 'r) option ->
+    common:(key -> 'a value -> 'b value -> 'r -> 'r) option ->
+    right_only:(key -> 'b value -> 'r -> 'r) option ->
+    'a t -> 'b t -> 'r -> 'r
+  (** [fold2 ~reflexive ~left_only ~common ~right_only m1 m2 r] iterates two maps
+      [m1] and [m2] simultaneously, updating the accumulator [r] at each binding:
+      - [left_only k v1 r] is called on bindings [k -> v1] present in [m1] but not [m2];
+      - [right_only k v2 r] is called on bindings [k -> v2] present in [m2] but not [m1];
+      - [common k v1 v2 r] is called on shared bindings. If [reflexive] is set,
+        [common] is not called on physically equal bindings ([v1 == v2]).
+        This improves performance by skipping shared subtrees.
+
+      Each of these can be [None] instead of a function, in which case the corresponding
+      bindings are ignored. This can dramatically speed up the fold, as it then
+      skips exploration of unneeded subtrees.
+
+      [fold2] explores bindings in the {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
+
+    Some examples:
+    {ul
+    {- Fold only on non-equal shared bindings (aliases as {!fold_on_nonequal_inter}):
+       {@ocaml skip[
+          MyMap.fold2 ~reflexive:true
+            ~left_only:None ~right_only:None
+            ~common:(Some (fun k v1 v2 r -> ...))
+       ]}
+        }
+    {- Fold only on non-equal union bindings (aliases as {!fold_on_nonequal_union}),
+       via a single shared function [f] taking optional arguments for values:
+       {@ocaml skip[
+          MyMap.fold2 ~reflexive:true
+            ~left_only:(Some (fun k v1 r -> f k (Some v1) None r))
+            ~right_only:(Some (fun k v2 r -> f k None (Some v2) r))
+            ~common:(Some (fun k v1 v2 r -> f k (Some v1) (Some v2) r))
+       ]}
+    }}
+
+      @since v0.15.0 *)
+
+  val iter2:
+    reflexive:bool ->
+    left_only:(key -> 'a value -> unit) option ->
+    common:(key -> 'a value -> 'b value -> unit) option ->
+    right_only:(key -> 'b value -> unit) option ->
+    'a t -> 'b t -> unit
+  (** Calls the argument function on all bindings, just like {!fold2}.
+      Unlike {!fold2}, each function returns unit so no accumulator is threaded.
+      @since v0.15.0 *)
 
   val fold_on_nonequal_inter : (key -> 'a value -> 'b value -> 'acc -> 'acc) ->
     'a t -> 'b t -> 'acc -> 'acc

--- a/src/signatures.ml
+++ b/src/signatures.ml
@@ -424,11 +424,9 @@ module type BASE_MAP = sig
   (** {2 Comparing two maps} *)
   (** Functions for equality, inclusion, and test for disjointness. *)
 
-  type ('map1,'map2) polysame_domain_for_all2 =
-    { f : 'a. 'a key -> ('a, 'map1) value -> ('a, 'map2) value -> bool; } [@@unboxed]
 
   val reflexive_same_domain_for_all2 :
-    ('map,'map) polysame_domain_for_all2 -> 'map t -> 'map t -> bool
+    ('map,'map,bool) polyfold2_inter -> 'map t -> 'map t -> bool
   (** [reflexive_same_domain_for_all2 f m1 m2] is true if and only if
       - [m1] and [m2] have the same domain (set of keys)
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
@@ -446,14 +444,14 @@ module type BASE_MAP = sig
       ]} *)
 
   val nonreflexive_same_domain_for_all2:
-    ('map1,'map2) polysame_domain_for_all2 -> 'map1 t -> 'map2 t -> bool
+    ('map1,'map2,bool) polyfold2_inter -> 'map1 t -> 'map2 t -> bool
   (** [nonreflexive_same_domain_for_all2 f m1 m2] is the same as
       {!reflexive_same_domain_for_all2}, but doesn't assume [f.f] is reflexive.
       It thus calls [f.f] on every binding, in ascending {{!unsigned_lt}unsigned order} of {!KEY.to_int}.
       Exits early if the domains mismatch or if [f.f] returns [false]. *)
 
   val reflexive_subset_domain_for_all2 :
-    ('map,'map) polysame_domain_for_all2 -> 'map t -> 'map t -> bool
+    ('map,'map,bool) polyfold2_inter -> 'map t -> 'map t -> bool
   (** [reflexive_subset_domain_for_all2 f m1 m2] is true if and only if
       - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
@@ -471,7 +469,7 @@ module type BASE_MAP = sig
       ]} *)
 
   val nonreflexive_subset_domain_for_all2 :
-    ('map1,'map2) polysame_domain_for_all2 -> 'map1 t -> 'map2 t -> bool
+    ('map1,'map2,bool) polyfold2_inter -> 'map1 t -> 'map2 t -> bool
   (** [nonreflexive_subset_domain_for_all2 f m1 m2] is true if and only if
       - [m1]'s domain is a subset of [m2]'s. (all keys defined in [m1] are also defined in [m2])
       - for all bindings [(k, v1)] in [m1] and [(k, v2)] in [m2], [f.f k v1 v2] holds
@@ -484,9 +482,7 @@ module type BASE_MAP = sig
 
       @since v0.13.0  *)
 
-  type ('map1,'map2) polyfor_all2 =
-    { f : 'a. 'a key -> ('a, 'map1) value option -> ('a, 'map2) value option -> bool; } [@@unboxed]
-  val reflexive_any_domain_for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
+  val reflexive_any_domain_for_all2 : ('map1,'map2,bool) polyfold2 -> 'map1 t -> 'map2 t -> bool
   (** [reflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
@@ -499,7 +495,7 @@ module type BASE_MAP = sig
 
       @since v0.13.0 *)
 
-  val nonreflexive_any_domain_for_all2 : ('map1,'map2) polyfor_all2 -> 'map1 t -> 'map2 t -> bool
+  val nonreflexive_any_domain_for_all2 : ('map1,'map2,bool) polyfold2 -> 'map1 t -> 'map2 t -> bool
   (** [nonreflexive_any_domain_for_all2 f m1 m2] is [true] if [f.f k v1_opt v2_opt] for all bindings [k]
       in [m1 ∪ m2] (where [vi_opt] is [Some v] if [k] is bound to [v] is [mi], and [None] otherwise).
 
@@ -513,10 +509,14 @@ module type BASE_MAP = sig
 
       @since v0.13.0 *)
 
+  val for_all2:
+    reflexive:bool ->
+    left_only:('a,bool) polyfold forall2_pred ->
+    common:('a,'b,bool) polyfold2_inter forall2_pred ->
+    right_only:('b,bool) polyfold forall2_pred ->
+    'a t -> 'b t -> bool
 
-  type 'map polycompare =
-      { f : 'a. 'a key -> ('a, 'map) value -> ('a, 'map) value -> int; } [@@unboxed]
-  val reflexive_compare : 'a polycompare -> 'a t -> 'a t -> int
+  val reflexive_compare : ('a,'a,int) polyfold2_inter -> 'a t -> 'a t -> int
   (** [reflexive_compare f m1 m2] is an order relation on maps.
       [m1] and [m2] are equal (return [0]) if they have the same domain and for all bindings
       [(k,v)] in [m1], [(k,v')] in [m2], we have [f v v' = 0].

--- a/test/model/model.ml
+++ b/test/model/model.ml
@@ -190,13 +190,16 @@ let rec fold_on_union f m0 m1 acc = match m0, m1 with
       | n when n < 0 -> fold_on_union f m0' m1 (f k0 (Some v0) None acc)
       | _ -> fold_on_union f m0 m1' (f k1 None (Some v1) acc)
 
-let reflexive_same_domain_for_all2 p m0 m1 =
+let same_domain_for_all2 ~reflexive p m0 m1 =
   let keys0 = keys m0
   and keys1 = keys m1
-  and p k = p k (List.assoc k m0) (List.assoc k m1) in
+  and p k =
+    let v0 = List.assoc k m0 and v1 = List.assoc k m1 in
+    if reflexive && v0 == v1 then true else p k v0 v1 in
   List.equal Int.equal keys0 keys1 && List.for_all p keys0
 
-let nonreflexive_same_domain_for_all2 = reflexive_same_domain_for_all2
+let reflexive_same_domain_for_all2 p = same_domain_for_all2 ~reflexive:true p
+let nonreflexive_same_domain_for_all2 p = same_domain_for_all2 ~reflexive:false p
 
 let nonreflexive_any_domain_for_all2 p m0 m1 =
   List.for_all (fun k -> p k (List.assoc_opt k m0) (List.assoc_opt k m1)) (keys m0 @ keys m1)

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -330,11 +330,25 @@ let tests =
         let t0 = interpret t0 and t1 = interpret t1 in
         ( Intmap.reflexive_same_domain_for_all2 f t0 t1,
           Model.reflexive_same_domain_for_all2 f (abstract t0) (abstract t1) ));
+    mk "for_all2_samedom_reflexive" (pair reflexive_same_domain_val two)
+      Print.bool (fun ((_, f), (t0, t1)) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.for_all2 ~reflexive:true ~left_only:False ~right_only:False
+            ~common:(F f) t0 t1,
+          Model.reflexive_same_domain_for_all2 f (abstract t0) (abstract t1) ));
     mk "nonreflexive_same_domain_for_all2"
       (pair nonreflexive_same_domain_val two) Print.bool
       (fun ((_, f), (t0, t1)) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         ( Intmap.nonreflexive_same_domain_for_all2 f t0 t1,
+          Model.nonreflexive_same_domain_for_all2 f (abstract t0) (abstract t1)
+        ));
+    mk "for_all2_samedom_nonrefl"
+      (pair nonreflexive_same_domain_val two) Print.bool
+      (fun ((_, f), (t0, t1)) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.for_all2 ~reflexive:false ~left_only:False ~right_only:False
+            ~common:(F f) t0 t1,
           Model.nonreflexive_same_domain_for_all2 f (abstract t0) (abstract t1)
         ));
     make_setop_test "difference" difference_fun snd Intmap.difference
@@ -343,9 +357,19 @@ let tests =
       (fun3 O.int O.char O.char bool)
       Intmap.reflexive_subset_domain_for_all2
       Model.reflexive_subset_domain_for_all2;
+    make_setcmp_test "for_all2_subsetdom_refl"
+      (fun3 O.int O.char O.char bool)
+      (fun f -> Intmap.for_all2 ~reflexive:true ~left_only:False ~right_only:True
+        ~common:(F f))
+      Model.reflexive_subset_domain_for_all2;
     make_setcmp_test "nonreflexive_subset_domain_for_all2"
       (fun3 O.int O.char O.char bool)
       Intmap.nonreflexive_subset_domain_for_all2
+      Model.nonreflexive_subset_domain_for_all2;
+    make_setcmp_test "for_all2_subsetdom_nonrefl"
+      (fun3 O.int O.char O.char bool)
+      (fun f -> Intmap.for_all2 ~reflexive:false ~left_only:False ~right_only:True
+        ~common:(F f))
       Model.nonreflexive_subset_domain_for_all2;
     make_setcmp_test "nonreflexive_any_domain_for_all2"
       (fun3 O.int (O.option O.char) (O.option O.char) bool)

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -371,6 +371,11 @@ let tests =
       (fun f -> Intmap.for_all2 ~reflexive:false ~left_only:False ~right_only:True
         ~common:(F f))
       Model.nonreflexive_subset_domain_for_all2;
+    make_setcmp_test "exists2"
+      (fun3 O.int O.char O.char bool)
+      (fun f -> Intmap.exists2 ~reflexive:false ~left_only:True ~right_only:False
+        ~common:(F f))
+      (fun f t1 t2 -> Model.nonreflexive_subset_domain_for_all2 (fun k v1 v2 -> f k v1 v2 |> not) t1 t2 |> not);
     make_setcmp_test "nonreflexive_any_domain_for_all2"
       (fun3 O.int (O.option O.char) (O.option O.char) bool)
       Intmap.nonreflexive_any_domain_for_all2

--- a/test/model/test.ml
+++ b/test/model/test.ml
@@ -49,6 +49,12 @@ let rec interpret = function
       let t0 = interpret m0 and t1 = interpret m1 in
       Intmap.slow_merge f t0 t1
 
+(* let interpret_with_print x =
+  let res = interpret x in
+  Format.printf " >> @[<v>%a@]@."
+  (Intmap.pretty (fun fmt i c -> Format.fprintf fmt "%d -> %c" i c)) res;
+   res *)
+
 let abstract t =
   let aux i a acc = (i, a) :: acc in
   List.sort Model.cmp_keys @@ Intmap.fold aux t []
@@ -383,12 +389,39 @@ let tests =
           Model.fold_on_nonequal_inter
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
+    mk "fold2_nonequal_inter" two
+      Print.(list (tup3 int char char))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 in
+        let t1 = interpret t1 in
+        ( Intmap.fold2
+            ~reflexive:true
+            ~left_only:None
+            ~common:(Some (fun i a b acc -> (i, a, b) :: acc))
+            ~right_only:None
+            t0 t1 [],
+          Model.fold_on_nonequal_inter
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
     mk "fold_on_inter" two
       Print.(list (tup3 int char char))
       (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         ( Intmap.fold_on_inter
             (fun i a b acc -> (i, a, b) :: acc)
+            t0 t1 [],
+          Model.fold_on_inter
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
+    mk "fold2_inter" two
+      Print.(list (tup3 int char char))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold2
+            ~reflexive:false
+            ~left_only:None
+            ~common:(Some (fun i a b acc -> (i, a, b) :: acc))
+            ~right_only:None
             t0 t1 [],
           Model.fold_on_inter
             (fun i a b acc -> (i, a, b) :: acc)
@@ -403,12 +436,38 @@ let tests =
           Model.fold_on_nonequal_union
             (fun i a b acc -> (i, a, b) :: acc)
             (abstract t0) (abstract t1) [] ));
+    mk "fold2_nonequal_union" two
+      Print.(list (tup3 int (option char) (option char)))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold2
+            ~reflexive:true
+            ~left_only:(Some (fun i a acc -> (i, Some a, None) :: acc))
+            ~common:(Some (fun i a b acc -> (i, Some a, Some b) :: acc))
+            ~right_only:(Some (fun i b acc -> (i, None, Some b) :: acc))
+            t0 t1 [],
+          Model.fold_on_nonequal_union
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
     mk "fold_on_union" two
       Print.(list (tup3 int (option char) (option char)))
       (fun (t0, t1) ->
         let t0 = interpret t0 and t1 = interpret t1 in
         ( Intmap.fold_on_union
             (fun i a b acc -> (i, a, b) :: acc)
+            t0 t1 [],
+          Model.fold_on_union
+            (fun i a b acc -> (i, a, b) :: acc)
+            (abstract t0) (abstract t1) [] ));
+    mk "fold2_union" two
+      Print.(list (tup3 int (option char) (option char)))
+      (fun (t0, t1) ->
+        let t0 = interpret t0 and t1 = interpret t1 in
+        ( Intmap.fold2
+            ~reflexive:false
+            ~left_only:(Some (fun i a acc -> (i, Some a, None) :: acc))
+            ~common:(Some (fun i a b acc -> (i, Some a, Some b) :: acc))
+            ~right_only:(Some (fun i b acc -> (i, None, Some b) :: acc))
             t0 t1 [],
           Model.fold_on_union
             (fun i a b acc -> (i, a, b) :: acc)


### PR DESCRIPTION
Draft MR for some API changes
- remove a lot of type definition which can be expressed by the `polyfold` types
- remove the `NODE_WITH_FIND` module type (argument to `WithForeign` functors, in favor of re-coding `find` in with foreign (via a new `MakeCore` functor). This is motivated by the fact I'll need more then find (namely `fold` and `forall` on `Map2`, and having an interface that includes all potential needs becomes tedious).
- prototype of the generic `for_all2`.

Things remaining to do:
- [x] document for_all2
- [x] non-polymorphic for_all2
- [x] set versions of for_all2
- [x] tests
- [x] do the same for fold2
- [x] do the same for iter2